### PR TITLE
Refactor and expand SOCOM1 classes and package

### DIFF
--- a/modules/SOCOM U.S Navy Seals/SOCOM1_classes.h
+++ b/modules/SOCOM U.S Navy Seals/SOCOM1_classes.h
@@ -11,127 +11,518 @@ namespace PlayStation2
 {
 	namespace SOCOM
 	{
-		namespace Offsets
+		class CNode
 		{
-			//	MatchData
-			static const unsigned int	o_GameEndAddr{ 0x5D708C };
-			static const unsigned int	o_GameForceMatch{ 0x1F66F4 };
+		public:
+			Mat4x4 mMatrix; //0x0000
+			AABB mAABB; //0x0040
+			int mType;	//0x0058
+			bool m_active : 1;	//0x005C
+			bool m_dynamic_motion : 1;
+			bool m_dynamic_light : 1;
+			bool m_landmark : 1;
+			bool m_light : 1;
+			bool m_prelight : 1;
+			bool m_fog : 1;
+			bool m_transparent : 1;
+			bool m_facade : 1;
+			bool m_reflective : 1;
+			bool m_bumpmap : 1;
+			bool m_hasDI : 1;
+			bool m_region_shift : 1;
+			bool m_has_visuals_prior_to_export : 1;
+			bool m_shadow : 1;
+			bool m_worldchild : 1;
+			bool m_char_common : 1;
+			bool m_NOTUSED : 1;
+			bool m_hasVisuals : 1;
+			bool m_hasMesh : 1;
+			bool m_scrolling_texture : 1;
+			bool m_light_dynamic : 1;
+			bool m_light_static : 1;
+			bool m_clutter : 1;
+			bool m_mtx_is_identity : 1;
+			bool m_use_parent_bbox : 1;
+			bool m_apply_clip : 1;
+			i32_t vfTable; //0x0060 
+			i32_t pParent; //0x0064	CNode*
+			char pad_0068[40]; //0x0068
+			i32_t pName; //0x0090
+			i32_t pNodeEx; //0x0094	CNodeEx*
+			char mGlobalLighting; //0x0098
+			char pad_0099[3]; //0x0099
+			float mOpacity; //0x009C
+			char pad_00A0[4]; //0x00A0
+			int mTickCount; //0x00A4
+			char pad_00A8[8]; //0x00A8
+			i32_t pModel; //0x00B0	CModel*
+			i32_t pModelName; //0x00B4	
+			char pad_00B8[8]; //0x00B8
 
-			//	Seal
-			static const unsigned int	o_LocalCamera{ 0x48D548 };
-			static const unsigned int	o_LocalSeal{ 0x48D548 };
-			static const unsigned int	o_SealArray{ 0x4D46A0 };
+		public:
+			CNode* GetParent();
+			class CEntity* GetEntity();
+			std::string GetName() const;
+			Vec3 GetWorldPos() const;
+			void SetWorldPos(const Vec3& newPos);
+			Mat4x4 GetWorldTM() const;
+			void SetWorldTM(const Mat4x4& newTM);
+			AABB GetLocalBounds() const;
+			AABB GetWorldBounds() const;
+			Vec3 GetRightVector() const;
+			Vec3 GetUpVector() const;
+			Vec3 GetForwardVector() const;
+			float GetYawAngleRadians() const;
+			float GetYawAngleDegrees() const;
+		}; //Size: 0x00B8
 
-			//	Visuals
-			static const unsigned int	o_fog{ 0x1E5AC0 };
-			static const unsigned int	o_fps1{ 0x48CF60 };
-			static const unsigned int	o_fps2{ 0x48CF64 };
-		}
+		class CNodeEx
+		{
+		public:
+			i32_t vfTable; //0x0000
+			i32_t pEntity; //0x0004	CZSealBody*
+		};	//Size: 0x0008
+
+		class CWorld : public CNode
+		{
+		public:
+			i32_t pCamera; //0x00B8	CZCamera*
+		
+		public:
+			static CWorld* GetDefaultInstance();
+			bool GetViewMatrix(Mat4x4* out);
+		};
+
+		class CAppCamera
+		{
+		private:
+			i32_t							vfTable;				//0x0000	
+			char							pad_0004[48];			//0x0004
+			i32_t							pCamera;				//0x0034	CZCamera*
+			i32_t							pTransforms;			//0x0038	CNode*
+			i32_t							pAttachedPlayer;		//0x003C	CZSealBody*
+			i32_t							pSkeletonRoot;			//0x0040	CZBodyPart*
+			char							pad_0044[12];			//0x0044
+			Vec3							mOrigin;				//0x0050
+			char							mCtrlView;				//0x005C
+			char							pad_005D[51];			//0x005D
+			char							mSavePeek;				//0x0090
+			char							mSaveView;				//0x0091
+			bool							bAutoDeathCam;			//0x0092
+			bool							bAllowDeathCamControl;	//0x0093
+			char							mCamDeathState;			//0x0094
+
+		public:
+			static CAppCamera*				GetDefaultInstance();
+			class CZCamera*					GetCamera();
+			class CZSeal*					GetAttachedPlayer();					//	returns attached player, if any
+			void							Reset();							//	sets camera to local player & restores camera position 
+			Vec3							GetPosition();
+			bool							GetCameraMatrix(FViewModel* out);
+			void							SetCamDistance(float dist);
+			bool							GetLookVector(Vec3* out);
+			bool							GetRightVector(Vec3* out);
+			bool							GetUpVector(Vec3* out);
+			bool							GetAttachedEntity(class CZSeal* out);
+			void							SetAttachedEntity(class CZSeal* pEntity);
+			bool							IsAttachedToLocalPlayer();
+
+		};
 
 		class CZCamera
 		{
-		private:
-			char							pad_0000[80];			//0x0000
-			Vector3							m_relativePosition;		//0x0050	
-			unsigned int					m_viewType;				//0x005C	//	0 = normal view : 2+ = zoom of sorts
+		private:		
+			Mat4x4 mModelMatrix; //0x0000
+			Vec4 mFogColor; //0x0040
+			float mFOV_h; //0x0050
+			float mFOV_v; //0x0054
+			char pad_0058[232]; //0x0058
+			float mZMin; //0x0140
+			float mZMax; //0x0144
+			float mZScale; //0x0148
+			char pad_014C[4]; //0x014C
+			Vec3 mFrustrum[3]; //0x0150
+			Vec3 mFullFrustrum[6]; //0x0174
+			int mFullFrustrumPoints; //0x01BC
+			Vec2 mSin; //0x01C0
+			Vec2 mCos; //0x01C8
+			Vec2 mTan; //0x01D0
+			Vec2 mCot; //0x01D8
+			char pad_01E0[224]; //0x01E0
+			Mat4x4 mtxWorldToView; //0x02C0
+			Mat4x4 mtxWorldToClip; //0x0300
+			Mat4x4 mtxViewToClip; //0x0340
+			Mat4x4 mtxViewToScreen; //0x0380
+			__int16 mtxHash; //0x03C0
+			char pad_03C2[678]; //0x03C2
 
 		public:
-			static CZCamera*				GetDefaultInstance();
-			Vector3							GetPosition();
+			static CZCamera* GetDefaultInstance();
+			bool WorldToScreen(const Vec3& pos, const Vec2& szScreen, Vec2* screen2D);
+			float GetFOVTanHalf();
+			float GetFOV();
+			unsigned __int16 GetViewMtxHash();
 		};
 
 		class CZSealObject
 		{
 		private:
 			char							pad_0000[48];	//0x0000
-			Vector3							m_absPosition;	//0x0030
+			Vec3							m_absPosition;	//0x0030
 			char							pad_003C[96];	//0x003C
 			float							m_selfVisible;	//0x009C	//	255 = visible : 0 = invisible
 
 		public:
 			static CZSealObject*			GetDefaultInstance();
-			Vector3							GetPosition();
-			void							SetPosition(Vector3 in);
+			Vec3							GetPosition();
+			void							SetPosition(Vec3 in);
 
 		};	//Size: 0x0100
 		
-		class CSealCtrl
+		class CZSealCtrl
 		{
 		private:
-			char pad_0000[384];	//0x0000
+			i32_t vfTable; //0x0000
+			i32_t pEntity; //0x0004	CZSealBody* 
+			float mThrottle[3]; //0x0008
+			float mLookTimer; //0x0014
+			Structs::RFloat mLookRate; //0x0018
+			char pad_0020[4]; //0x0020
+			Vec3 N00006878; //0x0024
+			Vec3 N000035D9; //0x0030
+			Vec3 N00006879; //0x003C
+			int mLookFlags; //0x0048
+			Structs::RFloat mScanAngle; //0x004C
+			char pad_0054[284]; //0x0054
+
 		};	//Size: 0x0180
+
+		class CTarget
+		{
+		public:
+			i32_t pEntity; //0x0000 CEntity*
+			Vec3 mVec; //0x0004
+			float mDistSq; //0x0010
+			float mDist; //0x0014
+			float mVisibility; //0x0018
+			float mAware; //0x001C
+			int mDiHandle; //0x0020
+			bool m_d_computed : 1;
+			bool m_known : 1;
+			bool m_visible : 1;
+			bool m_hostile : 1;
+			bool m_targeted : 1;
+			bool m_dirty_di : 1;
+			bool m_unused : 2;
+			char pad_0025[3]; //0x0025
+
+		public:
+			class CZSeal* GetEntity();
+			bool WasRecentlyVisible() const;
+			bool IsVisible() const;
+			bool IsHostile() const;
+		}; //Size: 0x0028
+
+		class CZBodyPart
+		{
+		public:
+			Vec3 mOrigin; //0x0000	// tends to be in local coordinates
+			i32_t pNode; //0x000C	CNode*
+			Vec4 mRotation; //0x0010
+			i32_t pParent; //0x0020	CZBodyPart* 
+			__int16 mID; //0x0024	
+			char pad_0026[2]; //0x0026
+
+		public:
+			CZBodyPart* GetParent();
+			CNode* GetNode();
+			__int16 GetID() const;
+			bool GetLocalTM(Mat4x4* out);
+			Vec3 GetLocalOrigin() const;
+			Vec4 GetLocalRotation() const;
+			bool GetWorldTM(const Mat4x4& model, Mat4x4* out);	// multiply by parent model to get world transform relative to model
+			std::string GetName();	// returns the name of the body part, if it has one
+		};	//Size: 0x0028
+
+		class CZAnim
+		{
+		public:
+			char pad_0000[72]; //0x0000
+		}; //Size: 0x0048
+		static_assert(sizeof(CZAnim) == 0x48);
+
+		class CSnd
+		{
+		public:
+			i32_t vfTable; //0x0000
+			char pad_0004[68]; //0x0004
+		}; //Size: 0x0048
+
+		class CPickup
+		{
+		public:
+			float mLifetime; //0x0000
+			i32_t pNode; //0x0004	CNode*
+			i32_t pData; //0x0008	PickupType*
+			Enums::EPICKUP_TYPE mType; //0x000C
+			bool bLocked; //0x000D
+			bool bSecondary; //0x000E
+			char mUnused; //0x000F
+			__int16 mID; //0x0010
+			__int16 mNetID; //0x0012
+			bool bVisibleByUnits; //0x0014
+
+		public:
+			CNode* GetPickupObject();
+			std::string GetName();
+			Vec3 GetWorldPos();
+			AABB GetWorldBounds();
+			Mat4x4 GetWorldTM();
+			Vec3 GetForwardVector();
+			Vec3 GetRightVector();
+			Vec3 GetUpVector();
+			float GetYawAngleDegrees();
+		}; //Size: 0x0015
 
 		class CZSeal
 		{
 		private:
-			char							pad_0000[20];				//0x0000
-			__int32							m_pName;					//0x0014
-			char							pad_0018[4];				//0x0018
-			Vector3							m_relativeLocation;			//0x001C
-			__int32							m_pSealObj;					//0x0028	//	CZSealObject
-			char							pad_002C[148];				//0x002C
-			__int32							m_pSealCtrl;				//0x00C0	//	CSealCtrl
-			ETeam							m_teamID;					//0x00C4
-			char							pad_00C8[152];				//0x00C8
-			__int8							m_zoomPos;					//0x0160
-			char							pad_0161[3];				//0x0161
-			float							m_fZoom;					//0x0164
-			char							pad_0168[704];				//0x0168
-			Vector3							m_relativeRotation;			//0x0428
-			char							pad_0434[168];				//0x0434
-			__int32							m_totalShotsFired;			//0x04DC
-			char							pad_04E0[48];				//0x04E0
-			__int32							m_totalShotsFired2;			//0x0510
-			char							pad_0514[56];				//0x0514
-			float							m_xhairBounce;				//0x054C
-			char							pad_0550[188];				//0x0550
-			__int32							m_PrimaryWeapon;			//0x060C
-			__int32							m_SecondaryWeapon;			//0x0610
-			__int32							m_EqSlot1;					//0x0614
-			__int32							m_EqSlot2;					//0x0618
-			__int32							m_EqSlot3;					//0x061C
-			char							pad_0620[100];				//0x0620
-			__int32							m_PrimaryAmmoType;			//0x0684
-			__int32							m_SecondaryAmmoType;		//0x0688
-			__int32							m_EqSlot1AmmoType;			//0x068C
-			__int32							m_EqSlot2AmmoType;			//0x0690
-			__int32							m_EqSlot3AmmoType;			//0x0694
-			char							pad_0698[100];				//0x0698
-			__int32							m_PrimaryMags[10];			//0x06FC
-			__int32							m_SecondaryMags[10];		//0x0724
-			__int32							m_EqSlot1Ammo;				//0x074C
-			char							pad_0750[36];				//0x0750
-			__int32							m_EqSlot2Ammo;				//0x0774
-			char							pad_0778[36];				//0x0778
-			__int32							m_EqSlot3Ammo;				//0x079C
-			char							pad_07A0[1156];				//0x07A0
-			EFireType						m_primaryFireType;			//0x0C24
-			EFireType						m_secondaryFireType;		//0x0C28
-			char							pad_0C2C[272];				//0x0C2C
-			__int32							m_curShotsFired;			//0x0D3C
-			float							m_fireCooldown;				//0x0D40
-			char							pad_0D44[84];				//0x0D44
-			__int32							m_totalShotsFired3;			//0x0D98
-			char							pad_0D9C[108];				//0x0D9C
-			__int32							m_gunHot;					//0x0E08
-			char							pad_0E0C[120];				//0x0E0C
-			__int32							m_gunHot2;					//0x0E84
-			char							pad_0E88[72];				//0x0E88
-			float							m_Health;					//0x0ED0
-			char							pad_0ED4[1180];				//0x0ED4
+			/* CEntity */
+			i32_t vfTable; //0x0000
+			char pad_0004[12]; //0x0004
+			Enums::EENTITY_TYPE mEntityType; //0x0010
+			char pad_0011[3]; //0x0011
+			i32_t pName; //0x0014
+			char pad_0018[4]; //0x0018
+			Vec3 mOrigin; //0x001C
+			i32_t pNode; //0x0028	CNode*
+			Vec3 mVel_M; //0x002C	
+			Vec3 mVel_W; //0x0038
+			Vec3 mVel_R; //0x0044
+			Vec4 mQuat; //0x0050
+			Vec3 mNextVel_W; //0x0060
+			char pad_006C[4]; //0x006C
+			Vec4 mNextQuat; //0x0070
+			Mat4x4 mMatrix; //0x0080
+			i32_t pSealCtrl; //0x00C0	CZSealCtrl*
+			Enums::ESEAL_TEAMS mTeamID; //0x00C4
+			float mMaxTargetRange; //0x00C8
+			int mMaxTargetCount; //0x00CC
+			int mTargetCount; //0x00D0
+			i32_t pTargetArray; //0x00D4	CTarget*
+			int mAwareCounter; //0x00D8
+			bool m_blink_eyes : 1; //0x00DC
+			bool m_drip_blood : 1;
+			bool m_animate_footsteps : 1;
+			bool m_interpolate_animations : 1;
+			bool m_lean_into_turns : 1;
+			bool m_do_weapon_recoil : 1;
+			bool m_check_player_collision : 1;
+			bool m_get_new_altitude : 1;
+			bool m_noshoot : 1;
+			bool m_update_targetlist : 1;
+			bool m_include_in_targetlist : 1;
+			bool m_isAlive : 1;
+			bool m_unused : 4;
+			char pad_00E0[130]; //0x00DE
+
+			/* CZSealBody */
+			char mZoomIndex; //0x0160
+			char mLastZoomIndex; //0x0161
+			char pad_0162[2]; //0x0162
+			float mZoomModifier; //0x0164
+			char pad_0168[260]; //0x0168
+			i32_t mSkeleton[33]; //0x026C	CZBodyPart*
+			char pad_02F0[20]; //0x02F0
+			Enums::ESEAL_STANCE mStance; //0x0304
+			Enums::ESEAL_LEAN mLean; //0x0305
+			char pad_0306[2]; //0x0306
+			float mShoulderRecoil; //0x0308
+			char pad_030C[20]; //0x030C
+			Vec3 mAimOrigin; //0x0320
+			char pad_032C[4]; //0x032C
+			Vec3 mAimAngles; //0x0330
+			char pad_033C[236]; //0x033C
+			Vec3 mRelativeRotation; //0x0428
+			char pad_0434[156]; //0x0434
+			Structs::SSealStats mSealStats; //0x04D0
+			char pad_0522[14]; //0x0522
+			Structs::CZKit mKit; //0x0530
+			char pad_0DC0[40]; //0x0DC0
+			i32_t pCarry; //0x0DE8	CZSealBody*
+			char pad_0DEC[220]; //0x0DEC
+			float mElevation; //0x0EC8
+			char pad_0ECC[4]; //0x0ECC
+			float mHealth; //0x0ED0
+			char pad_0ED4[80]; //0x0ED4
+			Vec2 mHeadHealth; //0x0F24
+			Vec2 mBodyHealth; //0x0F2C
+			Vec2 mArmHealth_L; //0x0F34
+			Vec2 mArmHealth_R; //0x0F3C
+			Vec2 mLegHealth_L; //0x0F44
+			Vec2 mLegHealth_R; //0x0F4C
+			float mArmor[6]; //0x0F54
+			char pad_0F6C[24]; //0x0F6C
+			bool m_HudUpdateViewCone : 1; //0x0F84
+			bool m_hudwashit : 1;
+			bool m_aim_point_valid : 1;
+			bool m_invincible : 1;
+			bool m_invisible : 1;
+			bool m_infiniteammo : 1;
+			bool m_doPostTick : 1;
+			bool m_restrainable : 1;
+			char pad_0F85[347]; //0x0F85
+			Vec3 mAimDir; //0x10E0
+			Vec3 mAimGoal; //0x10EC
+			Vec3 mAimPoint; //0x10F8
+			Vec3 mReticlePt; //0x1104
+			Vec3 mAimNorm; //0x1110
+			Vec3 mPrevAimPoint; //0x111C
+			Vec3 mPrevAimNorm; //0x1128
+			Vec3 mPrevReticlePt; //0x1134
+			Vec3 mCurrAimPos; //0x1140
+			char pad_114C[4]; //0x114C
+			Vec3 mCurFirePos; //0x1150
+			char pad_115C[4]; //0x115C
+			Vec3 mSkeletonRoot; //0x1160
 
 		public:
 			static CZSeal*					GetDefaultInstance();
 			bool							IsValid();
-			CZSealObject*					GetSealObject();
-			Vector3							GetPosition();
-			bool							SetPosition(Vector3 in);
+			bool							IsPlayerEntity();
+			CNode*							GetSealObject();
+			Enums::EENTITY_TYPE				GetEntityType() const { return this->mEntityType; }	//	0x0010	/* @TODO: move to cpp */
+			Structs::CZKit*					GetKit();
+			Vec3							GetPosition();
+			float							GetAngleDegrees();
+			float							GetAngleRadians();
+			bool							SetPosition(Vec3 in);
 			std::string						GetName();
-			ETeam							GetTeam();
+			Enums::ESEAL_TEAMS				GetTeam();
+			Enums::ESEAL_STANCE				GetStance();
+			void							SetTeam(const Enums::ESEAL_TEAMS& newTeam);
 			float							GetHealth();
 			bool							IsAlive();
+			bool							IsVisible(CZSeal* pOther);
+			bool							IsFriendly(CZSeal* pOther);
+			bool							IsEnemy(CZSeal* pOther);
+			bool							IsNonCombatant(CZSeal* pOther);
+			bool							IsSpecialEnemy(CZSeal* pOther);
+			void							SetInvincible(bool invincible) { this->m_invincible = invincible; }	//	0x0F85
+			bool							IsInvincible() { return this->m_invincible; }	//	0x0F85
+			void							SetInvisible(bool invisible) { this->m_invisible = invisible; }	//	0x0F85
+			bool							IsInvisible() { return this->m_invisible; }	//	0x0F85
+			void							SetInfiniteAmmo(bool infinite) { this->m_infiniteammo = infinite; }	//	0x0F85
+			bool							IsInfiniteAmmo() { return this->m_infiniteammo; }	//	0x0F85
+			bool							GetTargets(std::vector<CTarget*>& outTargets);
+
+			/**/
+			bool GetWorldTM(Mat4x4* out);
+			bool SetWorldPos(const Vec3& newPos);
+			bool GetWorldPos(Vec3* out);
+			bool GetLocalBounds(AABB* out);
+			bool GetWorldBounds(AABB* out);
+			bool GetForwardVector(Vec3* out);
+			bool GetRightVector(Vec3* out);
+			bool GetUpVector(Vec3* out);
+
+			//
+			bool							GetBoneByIndex(int boneIndex, CZBodyPart** out);
+			bool							GetBoneWorldTMByIndex(int boneIndex, Mat4x4* out);
+			bool							GetBoneLocationByIndex(const int& boneIndex, Vec3& outPosition);
+			bool							GetBoundingBox(AABB* outBounds);	//	creates a bounding box around the player, using the skeleton bones
+			bool							GetEquippedWeapon(class CZWeapon& outWeapon);
+			bool							SetEquippedWeapon(const Enums::EWEAPON& newWeapon);
+			bool							SetEquipment(__int32 mPrimary, __int32 mSecondary, __int32 mEq1, __int32 mEq2, __int32 mEq3);
+			bool							GetWeapon(const Enums::EWEAPONEQUIP_INDEX& mSlot, class CZWeapon& outWeapon);
+			bool							SetWeapon(const Enums::EWEAPONEQUIP_INDEX& mSlot, const Enums::EWEAPON& newWeapon);
+			bool							GetAmmoProperties(const Enums::EWEAPONEQUIP_INDEX& mSlot, class CZAmmo& outAmmo);
+			bool							SetAmmoProperties(const Enums::EWEAPONEQUIP_INDEX& mSlot, const Enums::EAMMO& newAmmo);
+			bool 							GiveWeapon(const Enums::EWEAPONEQUIP_INDEX& mSlot, const int& newWeaponIndex);
+			bool							GiveAmmoType(const Enums::EWEAPONEQUIP_INDEX& mSlot, const int& newAmmoIndex);
+			bool							GiveAmmo(const Enums::EWEAPONEQUIP_INDEX& mSlot, int amount = 0, int mags = 0);
+			bool							GiveFireMode(const Enums::EWEAPONEQUIP_INDEX& mSlot, const int& newFireModeIndex);
+			bool							GiveLoadout(const Enums::EWEAPONEQUIP_INDEX& mSlot, const int& newWeaponIndex, const int& newAmmoIndex, const int& newFireModeIndex, const int& ammo = 0, const int& mags = 0);
+			bool							RefreshLoadout();	//	refills munitions for all slots
+			void							SetAimPoint(const Vec3& newAim);
+			bool							SetAimTarget(CZSeal* pTarget, bool bVisible = false, const Enums::ESEALBONES_INDEX& bone = Enums::ESEALBONES_head);
 		};	//Size: 0x1370
 		
+		class CEntity : public CZSeal
+		{
+		
+		};
+		
+		class CZSealBody : public CZSeal
+		{
+		
+		};
+
+		class CZWeapon
+		{
+		public:
+			i32_t							vfTable;					//0x0000	//	vfTable
+			i32_t							pName;						//0x0004
+			i32_t							pDisplayName;				//0x0008
+			i32_t							pTextureName;				//0x000C
+			i32_t							pIconName;					//0x0010
+			i32_t							pGearName;					//0x0014
+			i32_t							pModelName;					//0x0018
+			i32_t							pBulletImpactName;			//0x001C
+			Enums::EWEAPON_FIREMODE			mMaxFireMode;				//0x0020
+			__int32							szMag;						//0x0024
+			__int32							defaultMags;				//0x0028
+			float							mSoundRadius;				//0x002C
+			float							mSoundRadiusSq;				//0x0030
+			Enums::EWEAPON_ENCUMBRANCE		Encumbrance;				//0x0034
+			char							pad_0035[3];				//0x0035
+			float							mMaxRange;					//0x0038
+			float							mEffectiveRange;			//0x003C
+			float							mMuzzleVelocity;			//0x0040
+			float							mImpactRadius;				//0x0044
+			float							mFireWait;					//0x0048
+			float							mReloadTime;				//0x004C
+			bool							bReloadAfterShot;			//0x0050
+			char pad_0051[3];
+			unsigned int mBits; //0x0054
+			float mRangeMin; //0x0058
+			float mRangeMax; //0x005C
+			int mItemID; //0x0060
+			i32_t pHitAnim; //0x0064	CZAnim*
+			i32_t pFireAnim; //0x0068	CZAnim*
+			i32_t pZoomFireAnim; //0x006C	CZAnim*
+			i32_t pDefaultSpecialAnim; //0x0070	CZAnim*
+			i32_t pSpecialMaterialAnim; //0x0074	CZAnim*
+			i32_t pSound_Reload; //0x0078	CSnd*
+			i32_t pSoundName_Reload; //0x007C
+			i32_t pAnimName_Hit; //0x0080
+			i32_t pAnimName_Fire; //0x0084
+			i32_t pAnimName_DefaultSpecial; //0x0088
+			i32_t pAnimName_SpecialMaterial; //0x008C
+			char pad_0090[12]; //0x0090
+			ZArray<CZAmmo> mLegalAmmoList; //0x009C
+			bool							bHasFireMode[4];			//0x00A8
+
+		public:
+			std::string GetName();
+		};
+
+		class CZAmmo
+		{
+		public:
+			i32_t							pAmmoName;					//0x0000
+			i32_t							pDisplayName;				//0x0004
+			float							bulletImpactDmg;			//0x0008
+			float							stun;						//0x000C
+			float							piercing;					//0x0010
+			float							explosionDamage;			//0x0014
+			float							explosionRadius;			//0x0018
+			char							pad_001C[4];				//0x001C
+
+		public:
+			std::string GetName();
+		};
+
 		class CZMatchData
 		{
 			
@@ -176,7 +567,12 @@ namespace PlayStation2
 		public:
 			static bool						isMatchEnded();
 			static void						ForceStartMatch();
+			static bool						GetEntities(std::vector<CZSeal*>* entities);
 			static bool						GetPlayers(std::vector<CZSeal*>* players);
+			static std::vector<class CZSeal*>	GetAlivePlayers();
+			static bool						GetAllPickups(std::vector<CPickup*>* pickups);
+			static bool						GetWeaponPickups(std::vector<CPickup*>* pickups);
+			static bool						GetAmmoPickups(std::vector<CPickup*>* pickups);
 		};
 
 		///	@TODO:	
@@ -202,8 +598,8 @@ namespace PlayStation2
 				EEquipment						e_selected_Equipment;
 
 			public:
-				Vector3							GetBulletPos();
-				void							SetBulletPos(Vector3 Pos);
+				Vec3							GetBulletPos();
+				void							SetBulletPos(Vec3 Pos);
 				void							GiveWeapon();
 				void							GiveAmmo();
 				void							GetLoadoutData();
@@ -216,7 +612,7 @@ namespace PlayStation2
 				char							pad_0000[20];		//0x0000
 				int								NamePTR;			//0x0014
 				char							pad_0018[4];		//0x0018
-				Vector3							Position;			//0x001C
+				Vec3							Position;			//0x001C
 				class CZSealObject* CPlayerMovement;	//0x0028
 				char							pad_0030[148];		//0x0030
 				int								TeamID;				//0x00C4
@@ -248,7 +644,7 @@ namespace PlayStation2
 				void							GiveAmmo(int amount, int mags = {});
 				void							GiveWeapon(unsigned int Slot, unsigned int Weapon);
 				void							RemoveWeaponsandAmmo();
-				void							Teleport(Vector3 Pos);
+				void							Teleport(Vec3 Pos);
 				void							ChangeTeams(ETeam newTeam);
 				void							SetHealth(float newHealth);
 				std::string						LogData();

--- a/modules/SOCOM U.S Navy Seals/SOCOM1_package.cpp
+++ b/modules/SOCOM U.S Navy Seals/SOCOM1_package.cpp
@@ -1,9 +1,9 @@
 #pragma once
-#include "../../../pch.h"
+#include "SOCOM1_package.h"
 
 /**
  * Name: PlayStation2 - PCSX2 :: SOCOM U.S NAVY SEALs
- * Version: 0.0.1
+ * Version: 1.0.0
  * Author: NightFyre
 */
 
@@ -12,22 +12,628 @@ namespace PlayStation2
 {
 	namespace SOCOM
 	{
+
+		i32_t GetWeaponByIndex(int index)
+		{
+			// index aligned with v_WeaponNames
+			static const std::vector<Enums::EWEAPON> v_Weapons =
+			{
+				Enums::EWEAPON::EWeapon_EMPTY,
+				Enums::EWEAPON::EWeapon_M4A1,
+				Enums::EWEAPON::EWeapon_M4A1_SD,
+				Enums::EWEAPON::EWeapon_M4A1_M203,
+				Enums::EWEAPON::EWeapon_M16A2,
+				Enums::EWEAPON::EWeapon_M16A2_M203,
+				Enums::EWEAPON::EWeapon_552,
+				Enums::EWEAPON::EWeapon_AK47,
+				Enums::EWEAPON::EWeapon_AKS74,
+				Enums::EWEAPON::EWeapon_M14,
+				Enums::EWEAPON::EWeapon_M63A,
+				Enums::EWEAPON::EWeapon_M60E3,
+				Enums::EWEAPON::EWeapon_STONER63,
+				Enums::EWEAPON::EWeapon_HK5,
+				Enums::EWEAPON::EWeapon_HK5_SD,
+				Enums::EWEAPON::EWeapon_UZI,
+				Enums::EWEAPON::EWeapon_F90,
+				Enums::EWEAPON::EWeapon_Remington870,
+				Enums::EWEAPON::EWeapon_MK3_A2,
+				Enums::EWEAPON::EWeapon_SR25,
+				Enums::EWEAPON::EWeapon_SR25_SD,
+				Enums::EWEAPON::EWeapon_M40A1,
+				Enums::EWEAPON::EWeapon_M87ELR,
+				Enums::EWEAPON::EWeapon_M82A1A,
+				Enums::EWEAPON::EWeapon_MARK23,
+				Enums::EWEAPON::EWeapon_MARK23_SD,
+				Enums::EWEAPON::EWeapon_9MM,
+				Enums::EWEAPON::EWeapon_M9,
+				Enums::EWEAPON::EWeapon_P226,
+				Enums::EWEAPON::EWeapon_F57,
+				Enums::EWEAPON::EWeapon_DE50,
+				Enums::EWEAPON::EWeapon_MODEL18,
+				Enums::EWEAPON::EWeapon_M79,
+				Enums::EWEAPON::EWeapon_MGL,
+				Enums::EWEAPON::EWeapon_M203,
+				Enums::EWEAPON::EWeapon_M67,
+				Enums::EWEAPON::EWeapon_HE,
+				Enums::EWEAPON::EWeapon_SMOKE,
+				Enums::EWEAPON::EWeapon_FLASHBANG,
+				Enums::EWEAPON::EWeapon_C4,
+				Enums::EWEAPON::EWeapon_CLAYMORE,
+				Enums::EWEAPON::EWeapon_SATCHEL,
+				Enums::EWEAPON::EWeapon_2XAMMO,
+				Enums::EWEAPON::EWeapon_M79_HE,
+				Enums::EWEAPON::EWeapon_M79_FRAG,
+				Enums::EWEAPON::EWeapon_M79_SMOKE,
+				Enums::EWEAPON::EWeapon_M203_HE,
+				Enums::EWEAPON::EWeapon_M203_FRAG,
+				Enums::EWEAPON::EWeapon_M203_SMOKE,
+				Enums::EWEAPON::EWeapon_KNIFE,
+				Enums::EWEAPON::EWeapon_FLASHLIGHT,	//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_DETONATOR,	//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_BINOCULARS,	//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_RESTRAINTS,	//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_LASER_DESIGNATOR,	//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_KEVLAR_ARMOR,	//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_KEVLAR_ARMOR_INSERT,	//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_MPBOMB,		//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_ATG_MISSILE,	//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_ExplodingFuel,	//	unknown, not used in SOCOM 1
+				Enums::EWEAPON::EWeapon_SATCHEL_EXPLOSION	//	unknown, not used in SOCOM 1
+			};
+
+			if (index >= 0 && index < v_Weapons.size())
+				return (i32_t)v_Weapons[index];
+
+			return 0; // Invalid index
+		}
+
+		i32_t GetAmmoTypeByIndex(int index)
+		{
+			// index aligned with v_AmmoNames
+			static const std::vector<Enums::EAMMO> v_AmmoTypes =
+			{
+				Enums::EAMMO::EWeaponAmmo_EMPTY,
+				Enums::EAMMO::EWeaponAmmo_M4A1,
+				Enums::EAMMO::EWeaponAmmo_M4A1_SD,
+				Enums::EAMMO::EWeaponAmmo_AK74,
+				Enums::EAMMO::EWeaponAmmo_AKS74,
+				Enums::EAMMO::EWeaponAmmo_M14,
+				Enums::EAMMO::EWeaponAmmo_HK5,
+				Enums::EAMMO::EWeaponAmmo_HK5_SD,
+				Enums::EAMMO::EWeaponAmmo_F90,
+				Enums::EAMMO::EWeaponAmmo_LONGRIFLE,
+				Enums::EAMMO::EWeaponAmmo_MK23,
+				Enums::EAMMO::EWeaponAmmo_DE50,
+				Enums::EAMMO::EWeaponAmmo_SHOTGUN,
+				Enums::EAMMO::EWeaponAmmo_M87ELR,
+				Enums::EAMMO::EWeaponAmmo_M67,
+				Enums::EAMMO::EWeaponAmmo_HE,
+				Enums::EAMMO::EWeaponAmmo_Smoke,
+				Enums::EAMMO::EWeaponAmmo_M141,
+				Enums::EAMMO::EWeaponAmmo_Satchel,
+				Enums::EAMMO::EWeaponAmmo_Claymore,
+				Enums::EAMMO::EWeaponAmmo_C4,
+				Enums::EAMMO::EWeaponAmmo_M203_HE,
+				Enums::EAMMO::EWeaponAmmo_M203_FRAG,
+				Enums::EAMMO::EWeaponAmmo_M203_SMOKE,
+				Enums::EAMMO::EWeaponAmmo_M79_HE,
+				Enums::EAMMO::EWeaponAmmo_M79_FRAG,
+				Enums::EAMMO::EWeaponAmmo_M79_SMOKE,
+				Enums::EAMMO::EWeaponAmmo_MP_BOMB,
+				Enums::EAMMO::EWeaponAmmo_ATG_Missile,
+				Enums::EAMMO::EWeaponAmmo_ExplosiveStuff
+			};
+
+			if (index >= 0 && index < v_AmmoTypes.size())
+				return (i32_t)v_AmmoTypes[index];
+
+			return 0; // Invalid index
+		}
+
+		i32_t GetTeamIDByIndex(int index)
+		{
+			static const std::vector<Enums::ESEAL_TEAMS> v_Teams =
+			{
+				Enums::ESEAL_TEAMS::ETeam_NONE,
+				Enums::ESEAL_TEAMS::ETeam_SEALS,
+				Enums::ESEAL_TEAMS::ETeam_TERRORIST,
+				Enums::ESEAL_TEAMS::ETeam_SPECTATOR,
+				Enums::ESEAL_TEAMS::ETeam_SP_ABLE,
+				Enums::ESEAL_TEAMS::ETeam_SP_BRAVO,
+				Enums::ESEAL_TEAMS::ETeam_SP_ENEMY_A,
+				Enums::ESEAL_TEAMS::ETeam_TURRET,
+				Enums::ESEAL_TEAMS::ETeam_GHOST
+			};
+
+			if (index >= 0 && index < v_Teams.size())
+				return (i32_t)v_Teams[index];
+
+			return 0; // Invalid index
+		}
+
+		bool GetBoneNameByIndex(int index, std::string& outResult)
+		{
+			if (index < 0 || index > v_BoneNames.size())
+				return false;	//	invalid index
+
+			outResult = v_BoneNames[index];
+		
+			return !outResult.empty();
+		}
+
+		namespace Dumper
+		{
+			void DumpMissionInfo()
+			{
+				/* get local seal object */
+				CZSeal* pSealBody = CZSeal::GetDefaultInstance();
+				if (!pSealBody)
+					return;
+			
+				/* get reference to entity array */
+				std::vector<CZSeal*> vSeals;
+				if (!CZMatchData::GetEntities(&vSeals))
+					return;	// failed to retrieve entities
+
+				/* get reference to pickup array */
+				std::vector<CPickup*> vPickups;
+				CZMatchData::GetAllPickups(&vPickups);
+
+				/* log entity count */
+				Console::LogMsg("[+]Dumping Mission Info\n");
+				Console::LogMsg("[+]Entity Count: %d\n", vSeals.size());
+				Console::LogMsg("[+]Pickup Count: %d\n", vPickups.size());
+				for (auto& pEntity : vSeals)
+				{
+					if (!pEntity)
+						continue;	// skip null pointers
+
+					/* log entity information */
+					Console::LogMsg("- %s { ID: %d, Team: 0x%llX }\n", pEntity->GetName().c_str(), pEntity->GetEntityType(), pEntity->GetTeam());
+				}
+
+				//	for (auto& pPickup : vPickups)
+				//	{
+				//		if (!pPickup)
+				//			continue;	// skip null pointers
+				//		/* log pickup information */
+				//		Console::LogMsg("- %s { ID: %d, Type: 0x%llX }\n", pPickup->GetName().c_str(), pPickup->GetType(), pPickup->GetEntityType());
+				//	}
+
+				Console::LogMsg("[+] finished dumping mission info\n\n");
+
+			}
+
+			void Dumper::DumpBoneNames()
+			{
+				std::vector<std::string> partNames;	//	bone names
+
+				/* get local seal object */
+				CZSeal* pSealBody = CZSeal::GetDefaultInstance();
+				if (!pSealBody)
+					return;
+
+				/* get body part array */
+				static const int szBodyParts = 0x21;
+				for (int i = 0; i <= szBodyParts; i++)
+				{
+					/* get body part class instance */
+					CZBodyPart* pBodyPart = nullptr;	// body part pointer
+					if (!pSealBody->GetBoneByIndex(i, &pBodyPart))
+						continue;	// skip null body part pointers
+
+					/* get bone name */
+					std::string partName = pBodyPart->GetName();
+					if (partName.empty())
+						continue; // skip empty names
+
+					partNames.push_back(partName);	// add bone name to list
+				}
+
+				/* log bone names */
+				Console::LogMsg("[+]Dumping Bone Names\n");
+				DWORD index = -1;
+				for (auto& name : partNames)
+				{
+					index++;
+
+					Console::LogMsg("%s\n", name.c_str());
+				}
+				Console::LogMsg("[+] finished dumping bones with count %d\n", partNames.size());
+
+				/* create enum list for bones */
+				Console::LogMsg("enum ESEALBONES_INDEX : int\n{\n\tESEALBONES_MIN = 0,\n");
+				for (auto& name : partNames)
+					Console::LogMsg("\tESEALBONES_%s,\n", name.c_str());
+				Console::LogMsg("\tESEALBONES_MAX = %s\n};\n\n", partNames[partNames.size() - 1]);
+			}
+		}
+
+		namespace Structs
+		{
+			bool CZKit::GetEquippedWeapon(i32_t& outWeapon)
+			{
+				if (this->mCurrentWeaponIndex < 0 || this->mCurrentWeaponIndex > this->mMaxWeaponIndex)
+					return false;
+
+				return GetWeaponAtIndex(this->mCurrentWeaponIndex, outWeapon);
+			}
+
+			bool CZKit::GetEquippedAmmo(i32_t& outAmmo)
+			{
+				if (this->mCurrentWeaponIndex < 0 || this->mCurrentWeaponIndex > this->mMaxWeaponIndex)
+					return false;
+
+				return GetAmmoAtIndex(this->mCurrentWeaponIndex, outAmmo);
+			}
+
+			bool CZKit::GetWeaponAtIndex(const Enums::EWEAPONEQUIP_INDEX& index, i32_t& outWeapon)
+			{
+				const auto& iIndex = (__int32)index;
+				if (iIndex < 0 || iIndex > this->mMaxWeaponIndex)
+					return false;
+
+				i32_t pWeapon = 0;
+				//	switch (index)
+				//	{
+				//		case Enums::EWeaponIndex_Primary: pWeapon = this->mPrimaryWeapon; break;
+				//		case Enums::EWeaponIndex_Secondary: pWeapon = this->mSecondaryWeapon; break;
+				//		case Enums::EWeaponIndex_EqSlot1: pWeapon = this->mEqSlot1; break;
+				//		case Enums::EWeaponIndex_EqSlot2: pWeapon = this->mEqSlot2; break;
+				//		case Enums::EWeaponIndex_EqSlot3: pWeapon = this->mEqSlot3; break;
+				//		default: return false;
+				//	}
+
+				pWeapon = this->pWeapons[index];
+
+				if (!pWeapon)
+					return false;
+
+				outWeapon = pWeapon;
+
+				return true;
+			}
+
+			bool CZKit::GetAmmoAtIndex(const Enums::EWEAPONEQUIP_INDEX& index, i32_t& outAmmo)
+			{
+				const auto& iIndex = (__int32)index;
+				if (iIndex < 0 || iIndex > this->mMaxWeaponIndex)
+					return false;
+
+				i32_t pAmmo = 0;
+				//	switch (index)
+				//	{
+				//	case Enums::EWeaponIndex_Primary: pAmmo = this->mPrimaryAmmoType; break;
+				//	case Enums::EWeaponIndex_Secondary: pAmmo = this->mSecondaryAmmoType; break;
+				//	case Enums::EWeaponIndex_EqSlot1: pAmmo = this->mEqSlot1AmmoType; break;
+				//	case Enums::EWeaponIndex_EqSlot2: pAmmo = this->mEqSlot2AmmoType; break;
+				//	case Enums::EWeaponIndex_EqSlot3: pAmmo = this->mEqSlot3AmmoType; break;
+				//	default: return false;
+				//	}
+
+				pAmmo = this->pAmmoTypes[index];
+
+				if (!pAmmo)
+					return false;
+
+				outAmmo = pAmmo;
+
+				return true;
+			}
+
+			bool CZKit::GetWeaponName(const Enums::EWEAPONEQUIP_INDEX& index, std::string& outName)
+			{
+				outName = GetWeaponName(index);
+				
+				return outName.size() > 0;
+			}
+
+			bool CZKit::GetAmmoName(const Enums::EWEAPONEQUIP_INDEX& index, std::string& outName)
+			{
+				outName = GetAmmoName(index);
+
+				return outName.size() > 0;
+			}
+
+			void CZKit::SetHeartbeatEnabled(bool enabled) { this->m_heartbeat_enabled = enabled; }
+
+			bool CZKit::GetHeartbeatEnabled() const { return this->m_heartbeat_enabled; }
+
+			std::string CZKit::GetWeaponName(const Enums::EWEAPONEQUIP_INDEX& index)
+			{
+				std::string result = ("ERROR");
+				const auto& iIndex = (__int32)index;
+				if (iIndex < 0 || iIndex > this->mMaxWeaponIndex)
+					return result;
+
+				i32_t pWeapon = 0;
+				if (!GetWeaponAtIndex(index, pWeapon))
+					return result;
+
+				auto weapon = (CZWeapon*)PS2Memory::GetEEAddr(pWeapon);
+				if (!weapon || !weapon->pName)
+					return result;
+
+				return (char*)PS2Memory::GetEEAddr(weapon->pName);
+			}
+
+			std::string CZKit::GetAmmoName(const Enums::EWEAPONEQUIP_INDEX& index)
+			{
+				std::string result = ("ERROR");
+				const auto& iIndex = (__int32)index;
+				if (iIndex < 0 || iIndex > this->mMaxWeaponIndex)
+					return result;
+
+				i32_t pWeapon = 0;
+				if (!GetAmmoAtIndex(index, pWeapon))
+					return result;
+
+				auto ammo = (CZAmmo*)PS2Memory::GetEEAddr(pWeapon);
+				if (!ammo)
+					return result;
+
+				i32_t pName = ammo->pDisplayName != 0 ? ammo->pDisplayName : ammo->pAmmoName;
+				if (!pName)
+					return result;
+
+				return (char*)PS2Memory::GetEEAddr(pName);
+			}
+		}
+
+
 		//----------------------------------------------------------------------------------------------------
-		//										CCAMERA
-		// - CCamera
+		//										CZCAMERA
+		// - CZCamera
 		//-----------------------------------------------------------------------------------
 
 		CZCamera* CZCamera::GetDefaultInstance()
 		{
-			if (Offsets::o_LocalCamera)
+			CAppCamera* pAppCamera = CAppCamera::GetDefaultInstance();
+			if (!pAppCamera)
 				return nullptr;
 
-			return PS2Memory::GetPtrShort<CZCamera*>(Offsets::o_LocalCamera);
+			return pAppCamera->GetCamera();
 		}
 
-		Vector3 CZCamera::GetPosition() { return this->m_relativePosition; }
+		float CZCamera::GetFOVTanHalf() { return this->mtxViewToClip.m[1][1]; }
+
+		float CZCamera::GetFOV()
+		{
+			float fov = 2.0f * atanf(1.0f / GetFOVTanHalf());
+			fov *= (180.0f / M_PI);	// degrees
+
+			return fov;
+		}
+
+		unsigned __int16 CZCamera::GetViewMtxHash()
+		{
+			return this->mtxHash;
+		}
+
+		bool CZCamera::WorldToScreen(const Vec3& pos, const Vec2& szScreen, Vec2* screen2D)
+		{
+			static float fov{ 60.f };
+
+			//  get camera view matrix
+
+			Mat4x4 mtxModel = this->mModelMatrix;
+
+			Vec3 cam_pos = mtxModel.Translation();
+			Vec3 cam_look = Vec3(-mtxModel.m[2][0], -mtxModel.m[2][1], -mtxModel.m[2][2]);
+			Vec3 cam_right = Vec3(mtxModel.m[0][0], mtxModel.m[0][1], mtxModel.m[0][2]);
+			Vec3 cam_up = Vec3(mtxModel.m[1][0], mtxModel.m[1][1], mtxModel.m[1][2]);
+
+			//  get direction or heading
+			Vec3 heading = pos - cam_pos;
+			float camX = heading.dot(cam_right);
+			float camY = heading.dot(cam_up);
+			float camZ = heading.dot(cam_look);
+
+			//  check if object is behind the camera
+			if (camZ <= 0.f)
+				return false;
+
+			//  apply perspective projection
+			float aspect = szScreen.x / szScreen.y;
+			float fov_radians = tan(fov * 0.5f * (M_PI / 180.f)); // Convert fov to radians and compute scaling factor
+
+			float pX = camX / (camZ * fov_radians * aspect);
+			float pY = camY / (camZ * fov_radians);
+
+			Vec2 res =
+			{
+				(pX + 1.0f) * 0.5f * szScreen.x,
+				(1.0f - pY) * 0.5f * szScreen.y // Invert Y because screen coordinates are top-down
+			};
+
+			if (res.x <= 0.f || res.y <= 0.0f)
+				return false;
+
+			if (res.x > szScreen.x || res.y > szScreen.y)
+				return false;
+
+			*screen2D = res;
+
+			return true;
+
+			CWorld* pWorld = CWorld::GetDefaultInstance();
+			if (!pWorld || !screen2D)
+				return false;
+
+			Mat4x4 mtxWorldToView;
+			if (!pWorld->GetViewMatrix(&mtxWorldToView))
+				return false;
+
+			{
+
+				Vec4 viewPos = Vec4(pos.x, pos.y, pos.z, 1.f) * mtxWorldToView;
+
+				Vec4 clipPos = viewPos * this->mtxViewToClip;
+				if (clipPos.w <= 0.1f)
+					return false; // behind the camera
+
+				Vec4 ndc4 = clipPos / clipPos.w;
+
+				return false;
+			}
 
 
+			const Mat4x4& mtxWorldToClip = this->mtxWorldToView * this->mtxViewToClip;	//	Model View Projection
+			Vec4 clipSpaceOrigin = this->mtxWorldToClip * Vec4(pos.x, pos.y, pos.z, 1.f);
+			if (clipSpaceOrigin.w <= 0.1f)
+				return false; // behind the camera
+
+			Vec4 ndc4 = clipSpaceOrigin / clipSpaceOrigin.w; // Normalize Device Coordinates (NDC)
+			Vec4 screen = this->mtxViewToScreen * ndc4; // Convert to screen coordinates
+
+			float x_ratio = (float)szScreen.x / (float)640.f;
+			float y_ratio = (float)szScreen.y / (float)448.f;
+			
+			//	screen.x = (screen.x - 2048.0f) * x_ratio + szScreen.x / 2.0f;
+			//	screen.y = (screen.y - 2048.0f) * y_ratio + szScreen.y / 2.0f;
+			//	screen.x = (screen.x / 4096.0f) * szScreen.x;
+			//	screen.y = (screen.y / 4096.0f) * szScreen.y;
+
+			screen.x = (ndc4.x + 1.0f) * 0.5f * szScreen.x;
+			screen.y = (1.0f - ndc4.y) * 0.5f * szScreen.y;
+			
+			//	screen.x = (ndc4.x + 1.0f) * 0.5f * szScreen.x;
+			//	screen.y = (1.0f - ndc4.y) * 0.5f * szScreen.y;
+			
+			*screen2D = { screen.x, screen.y };
+			
+			return true;
+
+			//	Vec3 ndc;
+			//	ndc.x = clipSpaceOrigin.x / clipSpaceOrigin.w;
+			//	ndc.y = clipSpaceOrigin.y / clipSpaceOrigin.w;
+			//	ndc.z = clipSpaceOrigin.z / clipSpaceOrigin.w;
+			//	
+			//	// Convert NDC to screen coordinates
+			//	*screen2D =
+			//	{
+			//		(szScreen.x / 2 * ndc.x) + (ndc.x + szScreen.x / 2),
+			//		-(szScreen.y / 2 * ndc.y) + (ndc.y + szScreen.y / 2)
+			//	};
+			//	
+			//	return true;
+		}
+
+		//----------------------------------------------------------------------------------------------------
+		//										CAPPCAMERA
+		// - CAppCamera
+		//-----------------------------------------------------------------------------------
+
+		CAppCamera* CAppCamera::GetDefaultInstance()
+		{
+			if (!Offsets::o_LocalCamera)
+				return nullptr;
+
+			return PS2Memory::GetPtrShort<CAppCamera*>(Offsets::o_LocalCamera);
+		}
+
+		CZCamera* CAppCamera::GetCamera() { return this->pCamera == 0 ? nullptr : (CZCamera*)PS2Memory::GetEEAddr(this->pCamera); }
+
+		CZSeal* CAppCamera::GetAttachedPlayer() { return this->pAttachedPlayer == 0 ? nullptr : (CZSeal*)PS2Memory::GetEEAddr(this->pAttachedPlayer); }
+
+		Vec3 CAppCamera::GetPosition() { return this->mOrigin; }
+
+		bool CAppCamera::GetCameraMatrix(FViewModel* out)
+		{
+			auto res = PS2Memory::ReadEE<FViewModel>(this->pCamera);
+
+			*out = res;
+
+			return true;
+		}
+
+		bool CAppCamera::GetLookVector(Vec3* out)
+		{
+			FViewModel view;
+			if (!GetCameraMatrix(&view))
+				return false;
+
+			*out = Vec3(-view.fwd.x, -view.fwd.y, -view.fwd.z);
+
+			return true;
+		}
+
+		bool CAppCamera::GetRightVector(Vec3* out)
+		{
+			FViewModel view;
+			if (!GetCameraMatrix(&view))
+				return false;
+
+			*out = Vec3(view.right.x, view.right.y, view.right.z);
+
+			return true;
+		}
+
+		bool CAppCamera::GetUpVector(Vec3* out)
+		{
+			FViewModel view;
+			if (!GetCameraMatrix(&view))
+				return false;
+
+			*out = Vec3(view.up.x, view.up.y, view.up.z);
+
+			return true;
+		}
+
+		void CAppCamera::Reset()
+		{
+			CZSeal* localPlayer = CZSeal::GetDefaultInstance();
+			if (!localPlayer)
+				return;
+
+			//	attach to local player if not already
+			if (!IsAttachedToLocalPlayer())
+				this->SetAttachedEntity(localPlayer);
+
+			SetCamDistance(0.f);	//	restore camera position
+		}
+
+		bool CAppCamera::GetAttachedEntity(CZSeal* out)
+		{
+			auto res = this->pAttachedPlayer;
+			if (!res)
+				return false;
+
+			out = (CZSeal*)PS2Memory::GetEEAddr(this->pAttachedPlayer);
+			
+			return out != nullptr;
+		}
+
+		void CAppCamera::SetAttachedEntity(CZSeal* pEntity)
+		{
+			auto addr = __int64(pEntity) - PS2Memory::GetEEBase();
+			this->pAttachedPlayer = addr;
+		}
+
+		bool CAppCamera::IsAttachedToLocalPlayer()
+		{
+			CZSeal* localPlayer = CZSeal::GetDefaultInstance();
+			if (!localPlayer)
+				return false;
+
+			auto res = this->pAttachedPlayer;
+			if (!res)
+				return false;
+
+			if ((__int64(localPlayer) - PS2Memory::GetEEBase()) != res)
+				return false;
+
+			return true;
+		}
+
+		void CAppCamera::SetCamDistance(float dist)
+		{
+			auto res = PS2Memory::ReadEE<FViewCache*>(this->pTransforms);
+			if (!res)
+				return;
+
+			res->m5.z = dist;
+		}
 
 		//----------------------------------------------------------------------------------------------------
 		//										CZSealObject
@@ -41,19 +647,314 @@ namespace PlayStation2
 			if (!pLocalSeal)
 				return nullptr;
 
-			return pLocalSeal->GetSealObject();
+			return reinterpret_cast<CZSealObject*>(pLocalSeal->GetSealObject());
 		}
 
-		Vector3 CZSealObject::GetPosition() { return this->m_absPosition; }
+		Vec3 CZSealObject::GetPosition() { return this->m_absPosition; }
 
-		void CZSealObject::SetPosition(Vector3 p) { this->m_absPosition = p; }
+		void CZSealObject::SetPosition(Vec3 p) { this->m_absPosition = p; }
 
 
 		//----------------------------------------------------------------------------------------------------
-		//										CSealCtrl
+		//										CZSealCtrl
 		// - CPlayer
 		//-----------------------------------------------------------------------------------
 
+		CNode* CNode::GetParent()
+		{
+			return (CNode*)PS2Memory::GetEEAddr(this->pParent);
+		}
+
+		CEntity* CNode::GetEntity()
+		{
+			auto pNode = (CNodeEx*)PS2Memory::GetEEAddr(this->pNodeEx);
+			if (!pNode)
+				return nullptr;
+
+			return (CEntity*)PS2Memory::GetEEAddr(pNode->pEntity);
+		}
+
+		std::string CNode::GetName() const
+		{
+			std::string result{};
+			if (!this->pName)
+				return result;
+
+			return (char*)PS2Memory::GetEEAddr(this->pName);
+		}
+
+		Vec3 CNode::GetWorldPos() const { return this->mMatrix.Translation(); }
+
+		void CNode::SetWorldPos(const Vec3& newPos)
+		{
+			this->mMatrix.m[3][0] = newPos.x; 
+			this->mMatrix.m[3][1] = newPos.y; 
+			this->mMatrix.m[3][2] = newPos.z; 
+		};
+
+		Mat4x4 CNode::GetWorldTM() const { return this->mMatrix; }
+
+		void CNode::SetWorldTM(const Mat4x4& newTM) { this->mMatrix = newTM; }
+
+		AABB CNode::GetLocalBounds() const { return this->mAABB; }
+
+		AABB CNode::GetWorldBounds() const
+		{
+			return this->mAABB + GetWorldPos();
+		}
+
+		Vec3 CNode::GetRightVector() const { return Vec3(mMatrix.m[0][0], mMatrix.m[0][1], mMatrix.m[0][2]); }
+		
+		Vec3 CNode::GetUpVector() const { return Vec3(mMatrix.m[1][0], mMatrix.m[1][1], mMatrix.m[1][2]); }
+		
+		Vec3 CNode::GetForwardVector() const { return Vec3(-mMatrix.m[2][0], -mMatrix.m[2][1], -mMatrix.m[2][2]); }
+
+		float CNode::GetYawAngleRadians() const
+		{
+			Mat4x4 m = this->mMatrix;
+
+			/* get radians */
+			return atan2(-m.m[2][0], m.m[2][2]);
+		}
+
+		float CNode::GetYawAngleDegrees() const
+		{
+			float yawDeg = GetYawAngleRadians() * (180.f / M_PI);
+
+			/* normalize 0-360 */
+			if (yawDeg < 0.f)
+				yawDeg += 360.f;
+
+			return yawDeg;
+		}
+
+		CWorld* CWorld::GetDefaultInstance()
+		{
+			if (!Offsets::o_World)
+				return nullptr;
+
+			return PS2Memory::GetPtrShort<CWorld*>(Offsets::o_World);
+		}
+
+		bool CWorld::GetViewMatrix(Mat4x4* out)
+		{
+			/* sceVu0CopyMatrix((int)v53, *(_DWORD *)(*(_DWORD *)(zdb::CWorld::m_world + 0xC0) + 0x3C0) + 0x20); */
+
+			/* validate camera */
+			if (!this->pCamera)
+				return false;
+
+			/* get camera */
+			CZCamera* pCamera = (CZCamera*)PS2Memory::GetEEAddr(this->pCamera);
+			if (!pCamera)
+				return false;
+
+			/* get ScratchPad Offset */
+			const auto& offset = pCamera->GetViewMtxHash();
+			if (offset <= 0 || offset >= ((1024 * 1) * 16))
+				return false;
+
+			/* read view matrix head from scratchpad */
+			const auto& mtx_base = PS2Memory::GetScratchPadBase() + offset;
+			if (mtx_base == offset)
+				return false;
+
+			/* copy matrix */
+			*out = *reinterpret_cast<Mat4x4*>(mtx_base + 0x20);
+
+			return true;
+		}
+
+
+		class CZSeal* CTarget::GetEntity()
+		{
+			if (!this->pEntity)
+				return nullptr;
+
+			return (CZSeal*)PS2Memory::GetEEAddr(this->pEntity);
+		}
+
+		bool CTarget::WasRecentlyVisible() const { return IsVisible() && this->mVisibility >= 1.5 && this->mVisibility <= 1.8; }
+		bool CTarget::IsVisible() const { return this->m_visible && this->mVisibility >= 2.0f; }
+		bool CTarget::IsHostile() const { return this->m_hostile; }
+
+
+		CZBodyPart* CZBodyPart::GetParent()
+		{
+			if (!this->pParent)
+				return nullptr;
+
+			return (CZBodyPart*)PS2Memory::GetEEAddr(this->pParent);
+		}
+
+		CNode* CZBodyPart::GetNode()
+		{
+			if (!this->pNode)
+				return nullptr;
+
+			return (CNode*)PS2Memory::GetEEAddr(this->pNode);
+		}
+
+		//----------------------------------------------------------------------------------------------------
+		//										CZBODYPART
+		// - CZBodyPart
+		//-----------------------------------------------------------------------------------
+
+		Vec3 CZBodyPart::GetLocalOrigin() const { return this->mOrigin;}
+		Vec4 CZBodyPart::GetLocalRotation() const { return this->mRotation; }
+		__int16 CZBodyPart::GetID() const { return this->mID; }
+
+		bool CZBodyPart::GetLocalTM(Mat4x4* out)
+		{
+			if (!this->pNode)
+				return false;
+
+			CNode* pNode = (CNode*)PS2Memory::GetEEAddr(this->pNode);
+			if (!pNode)
+				return false;
+
+			*out = pNode->mMatrix;
+		
+			return true;
+		}
+		
+		bool CZBodyPart::GetWorldTM(const Mat4x4& model, Mat4x4* out)
+		{
+			/* get body part matrix */
+			Mat4x4 base_matrix;
+			if (!GetLocalTM(&base_matrix))
+				return false;
+			
+			if (!this->pParent)
+			{
+				*out = base_matrix * model;
+				return true;
+			}
+
+			/* iterate body part tree */
+			bool bFoundParents{ false };	// flag to check if parent body parts were found
+			CZBodyPart* pBodyPart = this;	// set current body part as current body part
+			do
+			{
+				/* get parent body part */
+				CZBodyPart* pParentBodyPart = pBodyPart->GetParent();
+				if (!pParentBodyPart)
+				{
+					bFoundParents = true;	// no parent found, exit loop
+					break;
+				}
+
+				/* get parent body part matrix */
+				Mat4x4 parentLocalMatrix;
+				if (!pParentBodyPart->GetLocalTM(&parentLocalMatrix))
+				{
+					bFoundParents = true;	// no parent node found, exit loop
+					break;
+				}
+
+				/* set pBodyPart to the parent & apply matrix transformation on the mtx buffer */
+				pBodyPart = pParentBodyPart;	// set parent body part as current body part
+				base_matrix = base_matrix * parentLocalMatrix;	// multiply parent matrix to temporary matrix
+
+			} while (!bFoundParents);
+
+			*out = base_matrix * model;
+
+			return true;
+		}
+
+		std::string CZBodyPart::GetName()
+		{
+			CNode* pNode = GetNode(); return pNode == nullptr ? "" : pNode->GetName();
+		}
+
+		//----------------------------------------------------------------------------------------------------
+		//										CPICKUP
+		// - CPickup
+		//-----------------------------------------------------------------------------------
+
+		CNode* CPickup::GetPickupObject()
+		{
+			if (!this->pNode)
+				return nullptr;
+
+			return (CNode*)PS2Memory::GetEEAddr(this->pNode);
+		}
+
+		std::string CPickup::GetName()
+		{
+			CNode* pNode = this->GetPickupObject();
+			if (!pNode)
+				return "";
+
+			if (!pNode->pName)
+				return "";
+
+			return (char*)PS2Memory::GetEEAddr(pNode->pName);
+		}
+		
+		Vec3 CPickup::GetWorldPos()
+		{
+			CNode* pNode = this->GetPickupObject();
+			if (!pNode)
+				return Vec3(0.f, 0.f, 0.f);
+
+			return pNode->GetWorldPos();
+		}
+		
+		AABB CPickup::GetWorldBounds()
+		{
+			CNode* pNode = this->GetPickupObject();
+			if (!pNode)
+				return AABB(Vec3(0.f, 0.f, 0.f), Vec3(0.f, 0.f, 0.f));
+			
+			return pNode->GetWorldBounds();
+		}
+		
+		Mat4x4 CPickup::GetWorldTM()
+		{
+			CNode* pNode = this->GetPickupObject();
+			if (!pNode)
+				return Mat4x4();
+
+			return pNode->GetWorldTM();
+		}
+		
+		Vec3 CPickup::GetForwardVector()
+		{
+			CNode* pNode = this->GetPickupObject();
+			if (!pNode)
+				return Vec3(0.f, 0.f, 0.f);
+
+			return pNode->GetForwardVector();
+		}
+		
+		Vec3 CPickup::GetRightVector()
+		{
+			CNode* pNode = this->GetPickupObject();
+			if (!pNode)
+				return Vec3(0.f, 0.f, 0.f);
+
+			return pNode->GetRightVector();
+		}
+		
+		Vec3 CPickup::GetUpVector()
+		{
+			CNode* pNode = this->GetPickupObject();
+			if (!pNode)
+				return Vec3(0.f, 0.f, 0.f);
+
+			return pNode->GetUpVector();
+		}
+		
+		float CPickup::GetYawAngleDegrees()
+		{
+			CNode* pNode = this->GetPickupObject();
+			if (!pNode)
+				return -1.f;
+
+			return pNode->GetYawAngleDegrees();
+		}
 
 		//----------------------------------------------------------------------------------------------------
 		//										CZSeal
@@ -70,22 +971,51 @@ namespace PlayStation2
 
 		bool CZSeal::IsValid()
 		{
-			return (this->m_pName > 0 && this->m_pSealObj > 0 && this->m_teamID > ETeam::NONE);
+			return (this != nullptr && this->mEntityType >= 0 && this->pName > 0 && this->pNode > 0 /*&& this->mTeamID > Enums::ESEAL_TEAMS::ETeam_NONE*/);
 		}
 
-		CZSealObject* CZSeal::GetSealObject() { return PS2Memory::GetPtrShort<CZSealObject*>(this->m_pSealObj); }
-
-		Vector3 CZSeal::GetPosition() { return this->m_relativeLocation; }
-
-		bool CZSeal::SetPosition(Vector3 p)
+		bool CZSeal::IsPlayerEntity()
 		{
-			CZSealObject* pObj = this->GetSealObject();
+			if (!this->IsValid())
+				return false;
+
+			return this->mEntityType == Enums::EENTITY_TYPE::ENT_TYPE_SEAL;
+		}
+
+		CNode* CZSeal::GetSealObject() 
+		{ 
+			if (!this->pNode)
+				return nullptr;
+
+			return (CNode*)PS2Memory::GetEEAddr(this->pNode);
+		}
+
+		Structs::CZKit* CZSeal::GetKit()
+		{
+			return (Structs::CZKit*)&this->mKit;
+		}
+
+		Vec3 CZSeal::GetPosition() { return this->mOrigin; }
+
+		bool CZSeal::SetPosition(Vec3 p)
+		{
+			CZSealObject* pObj = reinterpret_cast<CZSealObject*>(this->GetSealObject());
 			if (!pObj)
 				return false;
 
 			pObj->SetPosition(p);
 
-			return (pObj->GetPosition() == p);
+			return true;
+		}
+
+		float CZSeal::GetAngleRadians()
+		{
+			return fmod(atan2(this->mQuat.y, this->mQuat.w), M_PI * 2.f) * 2;
+		}
+
+		float CZSeal::GetAngleDegrees()
+		{
+			return 0.f;
 		}
 
 		std::string CZSeal::GetName()
@@ -93,14 +1023,824 @@ namespace PlayStation2
 			if (!this->IsValid())
 				return "";
 			
-			return (char*)PS2Memory::GetAddr(this->m_pName);
+			return (char*)PS2Memory::GetEEAddr(this->pName);
 		}
 
-		ETeam CZSeal::GetTeam() { return (ETeam)this->m_teamID; }
+		Enums::ESEAL_TEAMS CZSeal::GetTeam() { return (Enums::ESEAL_TEAMS)this->mTeamID; }
 
-		float CZSeal::GetHealth() { return this->m_Health * 100.f; }
+		Enums::ESEAL_STANCE CZSeal::GetStance()
+		{
+			return this->mStance;
+		}
 
-		bool CZSeal::IsAlive() { return this->m_Health > 0.0f; }
+		void CZSeal::SetTeam(const Enums::ESEAL_TEAMS& newTeam)
+		{
+			/* @TODO: prevent setting unrealistic id's */
+			this->mTeamID = newTeam;
+		}
+
+		float CZSeal::GetHealth() { return this->mHealth * 100.f; }
+
+		bool CZSeal::IsAlive() { return this->mHealth > 0.0f; }
+
+		bool CZSeal::IsVisible(CZSeal* pOther)
+		{
+			if (!this->IsValid() || !pOther->IsValid() || this->mTargetCount <= 0 || this->mMaxTargetCount <= 0)
+				return false;
+
+			unsigned __int64 pTargetArray = PS2Memory::GetEEAddr(this->pTargetArray);
+			if (!pTargetArray)
+				return false;	//	no target array, cannot check visibility
+
+			for (int i = 0; i < this->mTargetCount; i++)
+			{
+				CTarget* pTarget = (CTarget*)(pTargetArray + (i * sizeof(CTarget)));
+				if (!pTarget)
+					return false;
+
+				CZSeal* pSeal = (CZSeal*)PS2Memory::GetEEAddr(pTarget->pEntity);
+				if (pSeal == pOther)
+					return pTarget->m_visible;
+			}
+
+			return false;
+		}
+
+		bool CZSeal::IsFriendly(CZSeal* pOther)
+		{
+			if (!pOther->IsValid())
+				return false;
+
+			auto& team = this->mTeamID;
+			auto other_team = pOther->GetTeam();
+			if (team == Enums::ESEAL_TEAMS::ETeam_SPECTATOR || other_team == Enums::ESEAL_TEAMS::ETeam_SPECTATOR || team == Enums::ESEAL_TEAMS::ETeam_TURRET || other_team == Enums::ESEAL_TEAMS::ETeam_TURRET)
+				return false;
+
+			if (team == other_team)
+				return true;
+
+			if (team == Enums::ESEAL_TEAMS::ETeam_SP_ABLE && other_team == Enums::ESEAL_TEAMS::ETeam_SP_BRAVO || team == Enums::ESEAL_TEAMS::ETeam_SP_BRAVO && other_team == Enums::ESEAL_TEAMS::ETeam_SP_ABLE)
+				return true;
+
+			//	std::vector<CTarget*> vTargets;
+			//	if (!GetTargets(vTargets))
+			//		return false;	//	no targets found, cannot check hostile state
+			//	
+			//	for (auto& ent : vTargets)
+			//	{
+			//		if (!ent)
+			//			continue;
+			//		
+			//		CZSeal* pTargetSeal = ent->GetEntity();
+			//		
+			//		if (!pTargetSeal || !pTargetSeal->IsValid())
+			//			continue;	//	skip invalid targets
+			//		
+			//		if (pTargetSeal != pOther)
+			//			continue;
+			//	
+			//		return ent->IsHostile();
+			//	}
+
+
+			return false;	//	not caring to compare campaign terorist teams at this time, though special characters seem to have designated team id
+		}
+
+		bool CZSeal::IsEnemy(CZSeal* pOther)
+		{
+			if (!this->IsValid() || !pOther->IsValid())
+				return false;
+
+			if (this->mTeamID == pOther->mTeamID)
+				return false;	//	same team, not an enemy
+
+			return ((unsigned int)pOther->mTeamID & 0xFF000000) == 0x40000000;		//	0x40000000 is the bitmask for enemy teams, so if the team id matches this, it's an enemy
+		}
+
+		bool CZSeal::IsNonCombatant(CZSeal* pOther)
+		{
+			if (!this->IsValid() || !pOther->IsValid() || IsEnemy(pOther))
+				return false;
+
+			return (((unsigned int)pOther->mTeamID & 0xF0000000) == 0xC0000000) ||  //	0xC0000000 is the bitmask for non-combatant teams, so if the team id matches this, it's a non-combatant
+				(((unsigned int)pOther->mTeamID & 0xF0000000) == 0xD0000000);		//	0xD0000000 is the bitmask for non-combatant teams, so if the team id matches this, it's a non-combatant
+		}
+
+		bool CZSeal::IsSpecialEnemy(CZSeal* pOther)
+		{
+			if (!this->IsValid() || !pOther->IsValid())
+				return false;
+
+			if (!this->IsEnemy(pOther))
+				return false;
+
+			uint32_t roleBits = (unsigned int)pOther->mTeamID & 0x0000FFFF;
+
+			return roleBits <= 0x0200;
+		}
+
+		bool CZSeal::GetTargets(std::vector<CTarget*>& outTargets)
+		{
+			if (!this->IsValid() || this->mTargetCount <= 0 || this->mMaxTargetCount <= 0)
+				return false;
+
+			unsigned __int64 pTargetArray = PS2Memory::GetEEAddr(this->pTargetArray);
+			if (!pTargetArray)
+				return false;	//	no target array, cannot check visibility
+
+			outTargets.clear();	//	clear output vector
+			for (int i = 0; i < this->mTargetCount; i++)
+			{
+				CTarget* pTarget = (CTarget*)(pTargetArray + (i * sizeof(CTarget)));
+				if (!pTarget)
+					continue;
+
+				outTargets.push_back(pTarget);	//	add target to output vector
+			}
+
+			return true;	// targets found
+		}
+
+		bool CZSeal::GetWorldTM(Mat4x4* out)
+		{
+			if (!this->IsValid())
+				return false;
+		
+			CNode* pNode = GetSealObject();
+			if (!pNode)
+				return false;
+
+			*out = pNode->GetWorldTM();
+
+			return true;
+		}
+
+		bool CZSeal::SetWorldPos(const Vec3& newPos)
+		{
+			if (!this->IsValid())
+				return false;
+
+			CNode* pNode = GetSealObject();
+			if (!pNode)
+				return false;
+
+			pNode->SetWorldPos(newPos);
+			
+			return true;
+		}
+
+		bool CZSeal::GetWorldPos(Vec3* out)
+		{
+			if (!this->IsValid())
+				return false;
+
+			CNode* pNode = GetSealObject();
+			if (!pNode)
+				return false;
+
+			*out = pNode->GetWorldPos();
+
+			return true;
+		}
+
+		bool CZSeal::GetLocalBounds(AABB* out)
+		{
+			if (!this->IsValid())
+				return false;
+
+			CNode* pNode = GetSealObject();
+			if (!pNode)
+				return false;
+
+			*out = pNode->GetLocalBounds();
+
+			return true;
+		}
+
+		bool CZSeal::GetWorldBounds(AABB* out)
+		{
+			if (!this->IsValid())
+				return false;
+
+			CNode* pNode = GetSealObject();
+			if (!pNode)
+				return false;
+
+			*out = pNode->GetWorldBounds();
+
+			return true;
+		}
+
+		bool CZSeal::GetForwardVector(Vec3* out)
+		{
+			if (!this->IsValid())
+				return false;
+
+			CNode* pNode = GetSealObject();
+			if (!pNode)
+				return false;
+
+			*out = pNode->GetForwardVector();
+
+			return true;
+		}
+
+		bool CZSeal::GetRightVector(Vec3* out)
+		{
+			if (!this->IsValid())
+				return false;
+
+			CNode* pNode = GetSealObject();
+			if (!pNode)
+				return false;
+
+			*out = pNode->GetRightVector();
+
+			return true;
+		}
+
+		bool CZSeal::GetUpVector(Vec3* out)
+		{
+			if (!this->IsValid())
+				return false;
+
+			CNode* pNode = GetSealObject();
+			if (!pNode)
+				return false;
+
+			*out = pNode->GetUpVector();
+			
+			return true;
+		}
+
+
+
+#define sincos(radian, s, c) s = sin(radian); c = cos(radian)
+
+		void RotatePoint(const Vec3& point, const Vec3& center, const float* angles, Vec3* result)
+		{
+
+			float sx, cx, sy, cy, sz, cz;
+			sincos(angles[1], sx, cx);
+			sincos(angles[2], sy, cy);
+			sincos(angles[0], sz, cz);
+			Vec3 rotatedPoint;
+			Vec3 dir;
+
+			dir = point - center;
+			rotatedPoint.x = point.x;
+			rotatedPoint.y = center.y + (dir.y * cz - dir.z * sz);
+			rotatedPoint.z = center.z + (dir.y * sz + dir.z * cz);
+
+			dir = rotatedPoint - center;
+			rotatedPoint.x = center.x + (dir.x * cx + dir.z * sx);
+			rotatedPoint.z = center.z + (dir.z * cx - dir.x * sx);
+
+			dir = rotatedPoint - center;
+
+			result->x = center.x + (dir.x * cy - dir.y * sy);
+			result->y = center.y + (dir.x * sy + dir.y * cy);
+			result->z = rotatedPoint.z;
+		}
+		
+		bool CZSeal::GetBoneByIndex(int boneIndex, CZBodyPart** out)
+		{
+			if (!this->IsValid())
+				return false;	// invalid seal body instance
+
+			if (boneIndex < 0 || boneIndex > Enums::ESEALBONES_MAX)
+				return false;	// invalid index
+
+			i32_t boneOffset = this->mSkeleton[boneIndex];	// get bone offset from skeleton array
+			if (boneOffset <= 0)
+				return false;	// invalid bone pointer
+
+			*out = (CZBodyPart*)PS2Memory::GetEEAddr(boneOffset);	// get bone index from skeleton arra
+
+			return true;
+		}
+
+		bool CZSeal::GetBoneWorldTMByIndex(int boneIndex, Mat4x4* out)
+		{
+
+			/* get bone body part reference */
+			CZBodyPart* pBodyPart = nullptr;
+			if (!GetBoneByIndex(boneIndex, &pBodyPart))
+				return false;
+
+			/* return the results */
+			return pBodyPart->GetWorldTM(this->mMatrix, out);
+
+
+			/* declare math constants */
+			const Mat4x4& modelWorldMatrix = this->mMatrix;
+			const Vec3& modelWorldOrigin = modelWorldMatrix.Translation(); //	 Vec3(modelWorldMatrix.m[3][0], modelWorldMatrix.m[3][1], modelWorldMatrix.m[3][2]);
+
+			/* get bone body part reference */
+			//	CZBodyPart* pBodyPart = nullptr;
+			//	if (!GetBoneByIndex(boneIndex, &pBodyPart))
+			//		return false;
+
+			/* get body part node */
+			CNode* pBodyPartNode = pBodyPart->GetNode();
+			if (!pBodyPartNode)
+				return false;	// invalid body part node
+
+			/* get bone world matrix */
+			Mat4x4 bodyPartLocalMatrix = pBodyPartNode->GetWorldTM();
+
+			Vec3 tempOrigin; // create temporary origin vector to store result
+			Mat4x4 tempMatrix; // create temporary matrix to store result
+			bool bFoundParents{ false };
+			do
+			{
+				CZBodyPart* pParentBodyPart = pBodyPart->GetParent();
+				if (!pParentBodyPart)
+				{
+					bFoundParents = true;	// no parent found, exit loop
+					break;
+				}
+				/* get parent body part node */
+				CNode* pParentBodyPartNode = pParentBodyPart->GetNode();
+				if (!pParentBodyPartNode)
+				{
+					bFoundParents = true;	// no parent node found, exit loop
+					break;
+				}
+
+				pBodyPart = pParentBodyPart;	// set parent body part as current body part
+
+				/* get parent bone world matrix */
+				Mat4x4 parentLocalMatrix = pParentBodyPartNode->GetWorldTM();
+				Vec3 parentLocalOrigin = pParentBodyPartNode->GetWorldPos();
+
+				tempOrigin += parentLocalOrigin;	// add parent origin to temporary origin
+				tempMatrix = tempMatrix * parentLocalMatrix;	// multiply parent matrix to temporary matrix
+
+			} while (!bFoundParents);
+
+			*out = tempMatrix * modelWorldMatrix;
+
+			return true;
+		}
+
+		bool CZSeal::GetBoneLocationByIndex(const int& boneIndex, Vec3& outPosition)
+		{
+			Mat4x4 boneWorldMX;
+			if (!GetBoneWorldTMByIndex(boneIndex, &boneWorldMX))
+				return false;	//	cannot get bone world matrix
+
+			outPosition = boneWorldMX.Translation();	// get bone world position from matrix translation
+
+			return true;
+		}
+
+		bool CZSeal::GetBoundingBox(AABB* outBounds)
+		{
+			if (!this->IsValid() || !this->pNode)
+				return false;
+
+			auto pNode = (CNode*)PS2Memory::GetEEAddr(this->pNode);
+			if (!pNode)
+				return false;
+
+			Vec3 origin = pNode->GetWorldPos();
+			AABB bounds = pNode->mAABB;
+			bounds.m_min += origin;
+			bounds.m_max += origin;
+
+			*outBounds = bounds;
+
+			return true;
+
+			/* get bounds by bones */
+			float fMIN = -100000.f;
+			float fMAX = 100000.f;
+			Vec3 mmin(fMAX, fMAX, fMAX);
+			Vec3 mmax(fMIN, fMIN, fMIN);
+			for (int i = 0; i < Enums::ESEALBONES_MAX; i++)
+			{
+				Vec3 bone;
+				if (!GetBoneLocationByIndex(i, bone))
+					continue;
+
+
+				if (bone.x < mmin.x)
+					mmin.x = bone.x;
+				if (bone.y < mmin.y)
+					mmin.y = bone.y;
+				if (bone.z < mmin.z)
+					mmin.z = bone.z;
+
+				//	MAX
+				if (bone.x > mmax.x)
+					mmax.x = bone.x;
+				if (bone.y > mmax.y)
+					mmax.y = bone.y;
+				if (bone.z > mmax.z)
+					mmax.z = bone.z;
+			}
+
+			*outBounds = AABB(mmin, mmax);
+
+			return true;
+		}
+
+		bool CZSeal::GetEquippedWeapon(CZWeapon& outWeapon)
+		{
+			/* Get CZKit , reference weapon index , return weapon at index */
+
+			Structs::CZKit mKit = this->mKit;
+			const auto& index = mKit.mCurrentWeaponIndex;
+			const auto& szArray = mKit.mMaxWeaponIndex;
+			if (index < 0 || index >= szArray)
+				return false;	//	invalid weapon index
+
+
+			i32_t pWeapon = 0;
+			Enums::EWEAPONEQUIP_INDEX weaponIndex = (Enums::EWEAPONEQUIP_INDEX)index;
+			//	switch (weaponIndex)
+			//	{
+			//		case Enums::EWeaponIndex_Primary: pWeapon = mKit.mPrimaryWeapon; break;
+			//		case Enums::EWeaponIndex_Secondary: pWeapon = mKit.mSecondaryWeapon; break;
+			//		case Enums::EWeaponIndex_EqSlot1: pWeapon = mKit.mEqSlot1; break;
+			//		case Enums::EWeaponIndex_EqSlot2: pWeapon = mKit.mEqSlot2; break;
+			//		case Enums::EWeaponIndex_EqSlot3: pWeapon = mKit.mEqSlot3; break;
+			//		default: return false;
+			//	}
+
+			pWeapon = mKit.pWeapons[weaponIndex];
+
+			if (!pWeapon)
+				return false;
+
+			outWeapon = PS2Memory::ReadEE<CZWeapon>(pWeapon);
+
+			return true;
+		}
+
+		bool CZSeal::SetEquippedWeapon(const Enums::EWEAPON& newWeapon)
+		{
+			Structs::CZKit& mKit = this->mKit;
+			const auto& index = mKit.mCurrentWeaponIndex;
+			const auto& szArray = mKit.mMaxWeaponIndex;
+			if (index < 0 || index >= szArray)
+				return false;	//	invalid weapon index
+
+			Enums::EWEAPONEQUIP_INDEX weaponIndex = (Enums::EWEAPONEQUIP_INDEX)index;
+			//	switch (weaponIndex)
+			//	{
+			//		case Enums::EWeaponIndex_Primary: mKit.mPrimaryWeapon = (i32_t)newWeapon; break;
+			//		case Enums::EWeaponIndex_Secondary: mKit.mSecondaryWeapon = (i32_t)newWeapon; break;
+			//		case Enums::EWeaponIndex_EqSlot1: mKit.mEqSlot1 = (i32_t)newWeapon; break;
+			//		case Enums::EWeaponIndex_EqSlot2: mKit.mEqSlot2 = (i32_t)newWeapon; break;
+			//		case Enums::EWeaponIndex_EqSlot3: mKit.mEqSlot3 = (i32_t)newWeapon; break;
+			//		default: return false;
+			//	}
+
+			mKit.pWeapons[weaponIndex] = (i32_t)newWeapon;
+			
+			return true;
+		}
+
+		bool CZSeal::SetEquipment(__int32 mPrimary, __int32 mSecondary, __int32 mEq1, __int32 mEq2, __int32 mEq3)
+		{
+			return false;
+		}
+
+		bool CZSeal::GetWeapon(const Enums::EWEAPONEQUIP_INDEX& mSlot, CZWeapon& outWeapon)
+		{
+			Structs::CZKit& mKit = this->mKit;
+			const auto& index = mKit.mCurrentWeaponIndex;
+			const auto& szArray = mKit.mMaxWeaponIndex;
+			if (index < 0 || index >= szArray)
+				return false;
+
+			i32_t pWeapon = 0;
+			//	switch (mSlot)
+			//	{
+			//		case Enums::EWeaponIndex_Primary: pWeapon = mKit.mPrimaryWeapon; break;
+			//		case Enums::EWeaponIndex_Secondary: pWeapon = mKit.mSecondaryWeapon; break;
+			//		case Enums::EWeaponIndex_EqSlot1: pWeapon = mKit.mEqSlot1; break;
+			//		case Enums::EWeaponIndex_EqSlot2: pWeapon = mKit.mEqSlot2; break;
+			//		case Enums::EWeaponIndex_EqSlot3: pWeapon = mKit.mEqSlot3; break;
+			//		default: return false;	//	invalid weapon index
+			//	}
+
+			pWeapon = mKit.pWeapons[mSlot];
+			if (!pWeapon)
+				return false;
+
+			outWeapon = PS2Memory::ReadEE<CZWeapon>(pWeapon);
+
+			return true;
+		}
+
+		bool CZSeal::SetWeapon(const Enums::EWEAPONEQUIP_INDEX& mSlot, const Enums::EWEAPON& newWeapon)
+		{
+			Structs::CZKit& mKit = this->mKit;
+			const auto& index = mKit.mCurrentWeaponIndex;
+			const auto& szArray = mKit.mMaxWeaponIndex;
+			if (index < 0 || index >= szArray)
+				return false;
+
+			//	switch (mSlot)
+			//	{
+			//		case Enums::EWeaponIndex_Primary: mKit.mPrimaryWeapon = (i32_t)newWeapon; break;
+			//		case Enums::EWeaponIndex_Secondary: mKit.mSecondaryWeapon = (i32_t)newWeapon; break;
+			//		case Enums::EWeaponIndex_EqSlot1: mKit.mEqSlot1 = (i32_t)newWeapon; break;
+			//		case Enums::EWeaponIndex_EqSlot2: mKit.mEqSlot2 = (i32_t)newWeapon; break;
+			//		case Enums::EWeaponIndex_EqSlot3: mKit.mEqSlot3 = (i32_t)newWeapon; break;
+			//		default: return false;	//	invalid weapon index
+			//	}
+
+			mKit.pWeapons[mSlot] = (i32_t)newWeapon;
+			return true;
+		}
+
+		bool CZSeal::GetAmmoProperties(const Enums::EWEAPONEQUIP_INDEX& mSlot, CZAmmo& outAmmo)
+		{
+			Structs::CZKit mKit = this->mKit;
+			const auto& index = mKit.mCurrentWeaponIndex;
+			const auto& szArray = mKit.mMaxWeaponIndex;
+			if (index < 0 || index >= szArray)
+				return false;
+
+			i32_t pAmmo = 0;
+			//	switch (mSlot)
+			//	{
+			//		case Enums::EWeaponIndex_Primary: pAmmo = mKit.mPrimaryAmmoType; break;
+			//		case Enums::EWeaponIndex_Secondary: pAmmo = mKit.mSecondaryAmmoType; break;
+			//		case Enums::EWeaponIndex_EqSlot1: pAmmo = mKit.mEqSlot1Ammo; break;
+			//		case Enums::EWeaponIndex_EqSlot2: pAmmo = mKit.mEqSlot2Ammo; break;
+			//		case Enums::EWeaponIndex_EqSlot3: pAmmo = mKit.mEqSlot3Ammo; break;
+			//		default: return false;	//	invalid weapon index
+			//	}
+
+			pAmmo = mKit.pAmmoTypes[mSlot];
+			if (!pAmmo)
+				return false;
+
+			outAmmo = PS2Memory::ReadEE<CZAmmo>(pAmmo);
+
+			return true;
+		}
+
+		bool CZSeal::SetAmmoProperties(const Enums::EWEAPONEQUIP_INDEX& mSlot, const Enums::EAMMO& newAmmo)
+		{
+			Structs::CZKit& mKit = this->mKit;
+			const auto& index = mKit.mCurrentWeaponIndex;
+			const auto& szArray = mKit.mMaxWeaponIndex;
+			if (index < 0 || index >= szArray)
+				return false;
+
+			//	switch (mSlot)
+			//	{
+			//		case Enums::EWeaponIndex_Primary: mKit.mPrimaryAmmoType = (i32_t)newAmmo; break;
+			//		case Enums::EWeaponIndex_Secondary: mKit.mSecondaryAmmoType = (i32_t)newAmmo; break;
+			//		case Enums::EWeaponIndex_EqSlot1: mKit.mEqSlot1Ammo = (i32_t)newAmmo; break;
+			//		case Enums::EWeaponIndex_EqSlot2: mKit.mEqSlot2Ammo = (i32_t)newAmmo; break;
+			//		case Enums::EWeaponIndex_EqSlot3: mKit.mEqSlot3Ammo = (i32_t)newAmmo; break;
+			//		default: return false;	//	invalid weapon index
+			//	}
+
+			mKit.pAmmoTypes[mSlot] = (i32_t)newAmmo;
+			
+			return true;
+		}
+
+		bool CZSeal::GiveWeapon(const Enums::EWEAPONEQUIP_INDEX& mSlot, const int& newWeaponIndex)
+		{
+			auto& kit = this->mKit;
+			if (mSlot < 0 || mSlot >= kit.mMaxWeaponIndex)
+				return false;	//	invalid weapon index
+
+
+			const auto& weapon = GetWeaponByIndex(newWeaponIndex);
+			if (!weapon)	//	check if weapon exists at index
+				return false;
+			
+			//	switch (mSlot)
+			//	{
+			//		case Enums::EWeaponIndex_Primary: kit.mPrimaryWeapon = weapon; break;
+			//		case Enums::EWeaponIndex_Secondary: kit.mSecondaryWeapon = weapon; break;
+			//		case Enums::EWeaponIndex_EqSlot1: kit.mEqSlot1 = weapon; break;
+			//		case Enums::EWeaponIndex_EqSlot2: kit.mEqSlot2 = weapon; break;
+			//		case Enums::EWeaponIndex_EqSlot3: kit.mEqSlot3 = weapon; break;
+			//		default: return false;	//	invalid weapon index
+			//	}
+
+			kit.pWeapons[mSlot] = weapon;
+
+			return true;
+		}
+
+		bool CZSeal::GiveAmmo(const Enums::EWEAPONEQUIP_INDEX& mSlot, int amount, int mags)
+		{
+			auto& kit = this->mKit;
+			if (mSlot < 0 || mSlot >= kit.mMaxWeaponIndex)
+				return false;	//	invalid weapon index
+
+			/* get the current weapon */
+			i32_t pWeapon = 0;
+			//	switch (mSlot)
+			//	{
+			//		case Enums::EWeaponIndex_Primary: pWeapon = kit.mPrimaryWeapon; break;
+			//		case Enums::EWeaponIndex_Secondary: pWeapon = kit.mSecondaryWeapon; break;
+			//		case Enums::EWeaponIndex_EqSlot1: pWeapon = kit.mEqSlot1; break;
+			//		case Enums::EWeaponIndex_EqSlot2: pWeapon = kit.mEqSlot2; break;
+			//		case Enums::EWeaponIndex_EqSlot3: pWeapon = kit.mEqSlot3; break;
+			//		default: return false;	//	invalid weapon index
+			//	}
+
+			pWeapon = kit.pWeapons[mSlot];
+
+			/* verify weapon */
+			if (!pWeapon)
+				return false;
+
+			/* get weapon properties */
+			const auto& weapon = PS2Memory::ReadEE<CZWeapon>(pWeapon);
+
+			/* set ammo for weapons with magazines */
+			if (mSlot <= 1)
+			{
+				for (int i = 0; i < (mags > 0 ? mags : weapon.defaultMags); i++)
+				{
+					switch (mSlot)
+					{
+					case Enums::EWeaponIndex_Primary: kit.mPrimaryMags[i] = amount > 0 ? amount : weapon.szMag; break;
+					case Enums::EWeaponIndex_Secondary: kit.mSecondaryMags[i] = amount > 0 ? amount : weapon.szMag; break;
+						//	case Enums::EWeaponIndex_EqSlot1: kit.mEqSlot1Ammo = amount > 0 ? amount : weapon.szMag; break;
+						//	case Enums::EWeaponIndex_EqSlot2: kit.mEqSlot2Ammo = amount > 0 ? amount : weapon.szMag; break;
+						//	case Enums::EWeaponIndex_EqSlot3: kit.mEqSlot3Ammo = amount > 0 ? amount : weapon.szMag; break;
+					default: return false;	//	invalid weapon index
+					}
+				}
+
+				/* exit */
+				return true;
+			}
+
+			/*set ammo for equipment*/
+			switch (mSlot)
+			{
+				case Enums::EWeaponIndex_EqSlot1: kit.mEqSlot1Ammo = amount > 0 ? amount : weapon.szMag; break;
+				case Enums::EWeaponIndex_EqSlot2: kit.mEqSlot2Ammo = amount > 0 ? amount : weapon.szMag; break;
+				case Enums::EWeaponIndex_EqSlot3: kit.mEqSlot3Ammo = amount > 0 ? amount : weapon.szMag; break;
+				default: return false;	//	invalid weapon index
+			}
+
+			return true;
+		}
+
+		bool CZSeal::GiveFireMode(const Enums::EWEAPONEQUIP_INDEX& mSlot, const int& newFireModeIndex)
+		{
+			auto& kit = this->mKit;
+			if (mSlot < 0 || mSlot >= kit.mMaxWeaponIndex)
+				return false;	//	invalid weapon index
+
+			/* get the current weapon */
+			i32_t pWeapon = 0;
+			//	switch (mSlot)
+			//	{
+			//	case Enums::EWeaponIndex_Primary: pWeapon = kit.mPrimaryWeapon; break;
+			//	case Enums::EWeaponIndex_Secondary: pWeapon = kit.mSecondaryWeapon; break;
+			//	case Enums::EWeaponIndex_EqSlot1: pWeapon = kit.mEqSlot1; break;
+			//	case Enums::EWeaponIndex_EqSlot2: pWeapon = kit.mEqSlot2; break;
+			//	case Enums::EWeaponIndex_EqSlot3: pWeapon = kit.mEqSlot3; break;
+			//	default: return false;	//	invalid weapon index
+			//	}
+
+			pWeapon = kit.pWeapons[mSlot];
+
+			/* verify weapon */
+			if (!pWeapon)
+				return false;
+
+			/* get weapon properties */
+			auto weapon = (CZWeapon * )PS2Memory::GetEEAddr(pWeapon);
+			if (!weapon)
+				return false;
+
+			if ((mSlot == Enums::EWeaponIndex_Primary || mSlot == Enums::EWeaponIndex_Secondary) && newFireModeIndex > 0)
+				kit.mWeaponFireTypes[mSlot] = (Enums::EWEAPON_FIREMODE)newFireModeIndex;
+
+			/* set weapon property 
+			@ATTN: PERSISTENT*/
+			weapon->bHasFireMode[newFireModeIndex] = true;	//	set fire mode at index
+		}
+
+		bool CZSeal::GiveAmmoType(const Enums::EWEAPONEQUIP_INDEX& mSlot, const int& newAmmoIndex)
+		{
+			auto& kit = this->mKit;
+			if (mSlot < 0 || mSlot >= kit.mMaxWeaponIndex)
+				return false;	//	invalid weapon index
+
+			const auto& ammo = GetAmmoTypeByIndex(newAmmoIndex);
+			if (!ammo)
+				return false;	//	check if ammo type exists at index
+
+			//	switch (mSlot)
+			//	{
+			//		case Enums::EWeaponIndex_Primary: kit.mPrimaryAmmoType = ammo; break;
+			//		case Enums::EWeaponIndex_Secondary: kit.mSecondaryAmmoType = ammo; break;
+			//		case Enums::EWeaponIndex_EqSlot1: kit.mEqSlot1Ammo = ammo; break;
+			//		case Enums::EWeaponIndex_EqSlot2: kit.mEqSlot2Ammo = ammo; break;
+			//		case Enums::EWeaponIndex_EqSlot3: kit.mEqSlot3Ammo = ammo; break;
+			//		default: return false;	//	invalid weapon index
+			//	}
+
+			kit.pAmmoTypes[mSlot] = ammo;
+
+			return true;
+		}
+
+		bool CZSeal::GiveLoadout(const Enums::EWEAPONEQUIP_INDEX& mSlot, const int& newWeaponIndex, const int& newAmmoIndex, const int& newFireModeIndex, const int& ammo, const int& mags)
+		{
+			GiveWeapon(mSlot, newWeaponIndex);
+			GiveAmmoType(mSlot, newAmmoIndex);
+			GiveAmmo(mSlot, ammo, mags);
+			GiveFireMode(mSlot, newFireModeIndex);
+			return true;
+		}
+
+		bool CZSeal::RefreshLoadout()
+		{
+			auto& kit = this->mKit;
+
+			for (int i = 0; i <= kit.mMaxWeaponIndex; i++)
+				GiveAmmo((Enums::EWEAPONEQUIP_INDEX)i);
+
+			return true;
+		}
+
+		void CZSeal::SetAimPoint(const Vec3& newAim)
+		{
+			this->mAimOrigin = newAim;			
+			this->mAimPoint = newAim;			
+			this->mPrevAimPoint = newAim;		
+			this->mReticlePt = newAim;			
+			this->mPrevReticlePt = newAim;		
+			//	this->mAimDir = newDir;
+			//	this->mAimAngles = newDir;
+		}
+
+		bool CZSeal::SetAimTarget(CZSeal* pTarget, bool bVisible, const Enums::ESEALBONES_INDEX& bone)
+		{
+			/* determine if target & source are valid */
+			if (!this->IsValid() || !this->IsAlive() || !pTarget || !pTarget->IsValid() || !pTarget->IsAlive())
+				return false;	// invalid source or target entity
+
+			/* determine if target is visible */
+			if (bVisible && !pTarget->IsVisible(pTarget))
+				return false;	// target failed visibility check
+
+			/* get target bone location */
+			Vec3 targetAimPoint;
+			if (!pTarget->GetBoneLocationByIndex(bone, targetAimPoint))
+				return false;
+
+			/* get direction */
+			Vec3 dir = targetAimPoint - this->mAimOrigin;
+			
+			/* set aim point */
+			SetAimPoint(targetAimPoint);
+
+			return true;
+		}
+
+
+		//----------------------------------------------------------------------------------------------------
+		//										CZWEAPON
+		// - CZWeapon
+		//-----------------------------------------------------------------------------------
+
+		std::string CZWeapon::GetName()
+		{
+			std::string result{};
+			i32_t pName = this->pName != 0 ? this->pName : this->pModelName;
+			if (!pName || pName <= 0xCC0000)
+				return result;
+
+			return (char*)PS2Memory::GetEEAddr(pName);
+		}
+
+
+		//----------------------------------------------------------------------------------------------------
+		//										CZWEAPON
+		// - CZWeapon
+		//-----------------------------------------------------------------------------------
+
+		std::string CZAmmo::GetName()
+		{
+			std::string result{};
+			i32_t pName = pDisplayName != 0 ? pDisplayName : pAmmoName;
+			if (!pName || pName <= 0xCC0000)
+				return result;
+
+			return (char*)PS2Memory::GetEEAddr(pName);
+		}
 
 		//----------------------------------------------------------------------------------------------------
 		//										MATCHDATA
@@ -109,7 +1849,7 @@ namespace PlayStation2
 
 		bool CZMatchData::isMatchEnded()
 		{
-			return (PS2Memory::ReadShort<int>(Offsets::o_GameEndAddr) == 0) ? true : false;
+			return (PS2Memory::ReadEE<int>(Offsets::o_GameEndAddr) == 0) ? true : false;
 		}
 
 		void CZMatchData::ForceStartMatch()
@@ -117,21 +1857,124 @@ namespace PlayStation2
 			//
 		}
 
-		bool CZMatchData::GetPlayers(std::vector<CZSeal*>* p)
+		bool CZMatchData::GetEntities(std::vector<CZSeal*>* entities)
 		{
 			std::vector<CZSeal*> result{};
 
-			const auto arr = PS2Memory::ReadShort<ZArray<CZSeal*>>(Offsets::o_SealArray).Data();
-			
+			const auto arr = PS2Memory::ReadEE<ZArray<CZSeal*>>(Offsets::o_SealArray).Data();
+
 			for (auto ent : arr)
 			{
 				if (!ent->IsValid())
 					continue;
 
+				//	CNode* pNode = ent->GetSealObject();
+				//	if (!pNode)
+				//		continue;	//	invalid node, skip
+				//	
+				//	if (!pNode->m_hasVisuals)
+				//		continue;
+
 				result.push_back(ent);
 			}
 
-			*p = result;
+			*entities = result;
+
+			return result.size() > 0;
+		}
+
+		bool CZMatchData::GetPlayers(std::vector<CZSeal*>* p)
+		{
+			std::vector<CZSeal*> entities{};
+			if (!GetEntities(&entities))
+				return false;
+
+			std::vector<CZSeal*> players{};
+			for (auto& ent : entities)
+			{
+				if (!ent->IsValid() || !ent->IsPlayerEntity())
+					continue;
+				players.push_back(ent);
+			}
+
+			*p = players;
+
+			return players.size() > 0;
+		}
+
+		std::vector<CZSeal*> CZMatchData::GetAlivePlayers()
+		{
+			std::vector<CZSeal*> result;
+
+			std::vector<CZSeal*> players;
+			if (GetPlayers(&players))
+			{
+				for (auto& player : players)
+				{
+					if (!player->IsAlive())
+						continue;
+
+					result.push_back(player);
+				}
+			}
+
+			return result;
+		}
+
+		bool CZMatchData::GetAllPickups(std::vector<CPickup*>* pickups)
+		{
+			std::vector<CPickup*> result{};
+
+			const auto arr = PS2Memory::ReadEE<ZArray<CPickup*>>(Offsets::o_PickupArray).Data();
+			if (arr.size() <= 0)
+				return false;
+
+			for (auto pickup : arr)
+				result.push_back(pickup);
+
+			*pickups = result;
+
+			return result.size() > 0;
+		}
+		
+		bool CZMatchData::GetWeaponPickups(std::vector<CPickup*>* pickups)
+		{
+			std::vector<CPickup*> result{};
+			std::vector<CPickup*> pickups_buff{};
+
+			if (!GetAllPickups(&pickups_buff))
+				return false;
+
+			for (const auto& pickup : pickups_buff)
+			{
+				if (pickup->mType != Enums::PICKUP_TYPE_WEAPON)
+					continue;
+
+				result.push_back(pickup);
+			}
+
+			*pickups = result;
+
+			return result.size() > 0;
+		}
+
+		bool CZMatchData::GetAmmoPickups(std::vector<CPickup*>* pickups)
+		{
+			std::vector<CPickup*> result{};
+			std::vector<CPickup*> pickups_buff{};
+
+			if (!GetAllPickups(&pickups_buff))
+				return false;
+
+			for (const auto& pickup : pickups_buff)
+			{
+				if (pickup->mType != Enums::PICKUP_TYPE_AMMO)
+					continue;
+
+				result.push_back(pickup);
+			}
+
+			*pickups = result;
 
 			return result.size() > 0;
 		}
@@ -285,7 +2128,7 @@ void CZSealBody::RemoveWeaponsandAmmo()
 ///---------------------------------------------------------------------------------------------------
 //	[CPLAYER]
 // Teleports this entity to desired position
-void CZSealBody::Teleport(Vector3 Pos)
+void CZSealBody::Teleport(Vec3 Pos)
 {
 	unsigned int test = (unsigned int)this->CPlayerMovement;
 	auto offset = (test + g_PS2Mem->BasePS2MemorySpace);

--- a/modules/SOCOM U.S Navy Seals/SOCOM1_package.h
+++ b/modules/SOCOM U.S Navy Seals/SOCOM1_package.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 
 /**
  * Name: PlayStation2 - PCSX2 :: SOCOM U.S NAVY SEALs
@@ -14,13 +15,122 @@ namespace PlayStation2
 		// --------------------------------------------------
 		// # Forwards
 		// --------------------------------------------------
+		typedef unsigned __int32  i32_t;
+
+		/* WEAPONS */
+#define WEAPON_MODEL_18 0xCC1730
+#define WEAPON_MARK_23 0xCC1A10
+#define WEAPON_F57 0xCC1CF0
+#define WEAPON_DE50 0xCC1FD0
+#define WEAPON_M9 0xCC22D0
+#define WEAPON_P226 0xCC25B0
+#define WEAPON_MARK23_SD 0xCC2880
+#define WEAPON_9MM_Pistol 0xCC2B60
+#define WEAPON_LASER_DESIGNATOR 0xCC2E40		//	unknown, not used in SOCOM 1
+#define WEAPON_MK3_A2_SHOTGUN 0xCC3110	//	unknown, not used in SOCOM 1
+#define WEAPON_REMINGTON_870 0xCC33F0	//	unknown, not used in SOCOM 1
+#define WEAPON_M16A2 0xCC36E0
+#define WEAPON_M16A2_M203 0xCC39C0
+#define WEAPON_M4A1 0xCC3CA0
+#define WEAPON_M4A1_SD 0xCC3F80
+#define WEAPON_M4A1_M203 0xCC4270
+#define WEAPON_552 0xCC4550
+#define WEAPON_AK47 0xCC4850
+#define WEAPON_AKS74 0xCC4B20
+#define WEAPON_M14 0xCC4E00
+#define WEAPON_M60E3 0xCC50D0
+#define WEAPON_M63A 0xCC53A0
+#define WEAPON_STONER_63 0xCC5680		//	unknown, not used in SOCOM 1
+#define WEAPON_HK5 0xCC5970
+#define WEAPON_HK5_SD 0xCC5C40
+#define WEAPON_F90 0xCC5F20
+#define WEAPON_9M_SUB 0xCC61F0
+#define WEAPON_M82A1A 0xCC64C0
+#define WEAPON_M40A1 0xCC67A0
+#define WEAPON_M87ELR 0xCC6AA0
+#define WEAPON_SR25_SD 0xCC6D90
+#define WEAPON_SR25 0xCC7080
+#define WEAPON_KNIFE 0xCC7370 	//	unknown, not used in SOCOM 1
+#define WEAPON_FLASHLIGHT 0xCC7650	//	unknown, not used in SOCOM 1
+#define WEAPON_DETONATOR 0xCC7920	//	unknown, not used in SOCOM 1
+#define WEAPON_BINOCULARS 0xCC7BF0	//	unknown, not used in SOCOM 1
+#define WEAPON_RESTRAINTS 0xCC7EC0
+#define WEAPON_M67 0xCC81A0
+#define WEAPON_HE_GRENADE 0xCC8490
+#define WEAPON_SMOKE 0xCC8760
+#define WEAPON_FLASHBANG 0xCC8A60
+#define WEAPON_SATCHEL 0xCC8D50
+#define WEAPON_CLAYMORE 0xCC9030
+#define WEAPON_C4 0xCC9300
+#define WEAPON_MPBOMB 0xCC95C0
+#define WEAPON_M203 0xCC9890
+#define WEAPON_M203_HE 0xCC9B50
+#define WEAPON_M203_FRAG 0xCC9E30
+#define WEAPON_M203_SMOKE 0xCCA120
+#define WEAPON_MGL 0xCCA410
+#define WEAPON_M79 0xCCA6E0
+#define WEAPON_M79_HE 0xCCA9B0
+#define WEAPON_M79_FRAG 0xCCAC90
+#define WEAPON_M79_SMOKE 0xCCAF70
+#define WEAPON_KEVLAR_ARMOR 0xCCB260
+#define WEAPON_KEVLAR_ARMOR_INSERT 0xCCB530
+#define WEAPON_2X_AMMO 0xCCB800
+#define WEAPON_ATG_MISSILE 0xCCBAE0
+#define WEAPON_EXPLODING_FUEL 0xCCBDC0
+#define WEAPON_SATCHEL_EXPLOSION 0xCCC090
+
+		/* AMMO TYPES */
+#define AMMO_9x19P 0xCC0C90				//	SMG_HK5, SMG_9MM, PISTOL_MODEL_18, PISTOL_9MM
+#define AMMO_9x19P_SD 0xCC0CD0			//	SMG_HK5_SD, PISTOL_9MM_SD
+#define AMMO_57x28 0xCC0D20				//	F57 , F90
+#define AMMO_LONGRIFLE 0xCC0D70			//	unknown
+#define AMMO_45ACP 0xCC0DC0				//	PISTOL_MK23
+#define AMMO_50AE 0xCC0E10				//	DE50 , 
+#define AMMO_545x39 0xCC0E60			//	AKS74
+#define AMMO_556x45_SD 0xCC0ED0			//	M4A1_SD , 
+#define AMMO_556x45 0xCC0F40			//	M4A1, M16A2, 552 , M63A
+#define AMMO_762x51 0xCC0F90			//	M40A1 , M14 , M60E3 , SR25
+#define AMMO_762x39_SD 0xCC0FE0			//	AK47 , 
+#define AMMO_762x39 0xCC1050			//	AK47 , 
+#define AMMO_50BMG 0xCC10C0				//	M82A1A , M87ELR
+#define AMMO_12GUAGE 0xCC1110			//	unknown
+#define AMMO_M67 0xCC1160
+#define AMMO_HE 0xCC11B0
+#define AMMO_SMOKE 0xCC1210
+#define AMMO_M141 0xCC1260
+#define AMMO_SATCHEL 0xCC12C0
+#define AMMO_CLAYMORE 0xCC1320
+#define AMMO_C4 0xCC1380
+#define AMMO_MPBOMB 0xCC13D0
+#define AMMO_M203_HE 0xCC1420
+#define AMMO_M203_FRAG 0xCC1490
+#define AMMO_M203_SMOKE 0xCC1500
+#define AMMO_M79_HE 0xCC1570
+#define AMMO_M79_FRAG 0xCC15C0
+#define AMMO_M79_SMOKE 0xCC1620
+#define AMMO_MISSILE 0xCC1680			//	unknown
+#define AMMO_EXPLOSIVE_STUFF 0xCC16D0	//	unknown
 
 		// --------------------------------------------------
 		// # Global functions
 		// --------------------------------------------------
+
+		i32_t GetWeaponByIndex(int index);
+		i32_t GetAmmoTypeByIndex(int index);
+		i32_t GetTeamIDByIndex(int index);
+		bool GetBoneNameByIndex(int index, std::string& outResult);
+
+		namespace Dumper
+		{
+			void DumpMissionInfo();	/* dumps entity & pickups array for the current mission , should be run once at the start of a mission to generate information */
+			void DumpWeaponStats();
+			void DumpAmmoStats();
+			void DumpBoneNames();
+		}
 	}
 }
 #pragma pack(pop)
-
+#include <PCSX2/CDK.h>
 #include "SOCOM1_structs.h"
 #include "SOCOM1_classes.h"
+#include "data/names.h"

--- a/modules/SOCOM U.S Navy Seals/SOCOM1_structs.h
+++ b/modules/SOCOM U.S Navy Seals/SOCOM1_structs.h
@@ -11,6 +11,639 @@ namespace PlayStation2
 {
 	namespace SOCOM
 	{
+		namespace Offsets
+		{
+			//	MatchData
+			static const unsigned int	o_GameEndAddr{ 0x5D708C };
+			static const unsigned int	o_GameForceMatch{ 0x1F66F4 };
+
+			//	Seal
+			static const unsigned int   o_World{ 0x48D288 };		//	CZWorld*
+			static const unsigned int	o_LocalCamera{ 0x48D488 };	//	CAppCamera*
+			static const unsigned int	o_LocalSeal{ 0x48D548 };	//	CZSealBody*
+			static const unsigned int	o_SealArray{ 0x4D46A0 };	//	ZArray<CZSeal*>
+			static const unsigned int	o_WeaponArray{ 0x52A490 };	//	ZArray<CZWeapon*>
+			static const unsigned int	o_AmmoArray{ 0x52A500 };	//	ZArray<CZAmmo*>
+			static const unsigned int	o_PickupArray{ 0x51E970 };	//	ZArray<CPickup*>
+			static const unsigned int   o_ProjectileArray{ 0x48E568 };	//	CZProjectileList*
+
+			//	Visuals
+			static const unsigned int	o_fog{ 0x1E5AC0 };
+			static const unsigned int	o_fps1{ 0x48CF60 };
+			static const unsigned int	o_fps2{ 0x48CF64 };
+		}
+
+		namespace Enums
+		{
+			enum EENTITY_TYPE : char
+			{
+				ENT_TYPE_UNKNOWN,
+				ENT_TYPE_RECYCLE,
+				ENT_TYPE_SEAL,
+				ENT_TYPE_TURRET
+			};
+
+			enum EPICKUP_TYPE : __int8
+			{
+				PICKUP_TYPE_ANIM = 1,
+				PICKUP_TYPE_WEAPON = 8,
+				PICKUP_TYPE_AMMO,
+				PICKUP_TYPE_BOMB = 11
+			};
+
+			enum EEQUIPITEM_TYPE : unsigned __int8
+			{
+				EQUIP_NONE = 0xff,
+
+				// Pistols
+				EQUIP_PISTOL = 0,
+				GLOCK18,
+				MARK23,
+				MARK23SD,
+				FIVE_SEVEN,
+				BERETTA,
+				P226,
+				DESERT_EAGLE,
+				HKP9S,
+				CHINESE_TYPE_59,
+				CROATIAN_HS95,
+				DESIGNATOR,
+
+				// SMGs
+				EQUIP_SMG = 30,
+				MP5,
+				STEYR_AUG9,
+				MP5SD,
+				FNP90,
+				STEYR_MACHINE_PISTOL,
+				SKORPION,
+				USI,
+
+				// Assault rifles
+				EQUIP_ASSAULT_RIFLE = 50,
+				M16A2,
+				M16_M203,
+				HKG11,
+				M4A1_CARBINE,
+				AR15,
+				SIG551_SWAT,
+				SIG552_COMMANDO,
+				AK47,
+				AKS74,
+				M14,
+				M4A1_CARBINE_M203,
+				M4A1_CARBINE_SILENCED,
+
+				// Shotguns
+				EQUIP_SHOTGUN = 80,
+				SPAS121,
+				RM3_SUPER_COMBAT,
+				JACKHAMMER,
+				REMINGTON870,
+
+				// Heavy machine guns
+				EQUIP_MACHINEGUN,
+				M60E,
+				STONER_M63A,
+				MARK46MOD0,
+
+				// Sniper rifles
+				EQUIP_SNIPER_RIFLE = 100,
+				BARRETM82A1,
+				REMMINGTON700,
+				MCMILLAN,
+				DRAGUNOV,
+				STONER_SR25_SILENCED,
+				STONER_SR25,
+
+				// Grenades
+				EQUIP_GRENADE = 120,
+				GRENADE,
+				SMOKE_GRENADE,
+				FLASHBANG,
+				PHOS_GRENADE,
+				TEARGAS_GRENADE,
+				HE_GRENADE,
+
+				// Heavy weapons
+				EQUIP_HEAVYWEAPON = 140,
+				M203,
+				MULTI_GRENADE_LAUNCHER,
+				M79,
+
+				// Explosives
+				EQUIP_EXPLOSIVE = 150,
+				C4,
+				SATCHEL_CHARGE,
+				CLAYMORE,
+				MPBOMB,
+				F18_MISSILE,
+				EXPLODING_BARREL,
+
+				// Melee weapons
+				EQUIP_MELEE = 160,
+				TASER,
+
+				// Launched grenades
+				EQUIP_LAUNCHED_GRENADE = 170,
+				M203_HE,
+				M203_IL,
+				M203_SMOKE,
+				M203_GAS,
+				M203_FRAG,
+				GL_HE,
+				GL_IL,
+				GL_SMOKE,
+				GL_FRAG,
+
+				// Equipment
+				EQUIP_EQUIPMENT = 180,
+				FLASHLIGHT,
+				BINOCULARS,
+				RESTRAINTS,
+				OLD_NVG_ID,
+				OLD_DESIGNATOR,
+				KNIFE,
+				DETONATOR,
+				DOUBLE_AMMO_LOAD,
+
+				// Armor
+				EQUIP_ARMOR = 200,
+				KEVLAR_ARMOR,
+				KEVLAR_INSERT_ARMOR,
+
+				EQUIP_END = 254
+			};
+
+			enum EEQUIPAMMO_TYPE : unsigned __int8
+			{
+				AMMO_NONE = 0xff,
+
+				A_9X19 = 1,
+				A_22_RIFLE,
+				A_45_ACP,
+				A_45_CASELESS,
+				A_50_AE,
+				A_50_AE_AP,
+				A_545X39_SOVIET,
+				A_556X45,
+				A_762X51,
+				A_50_BROWNING,
+				A_FRAG_GRENADE,
+				A_SMOKE_GRENADE,
+				A_TEARGAS_GRENADE,
+				A_FLASHBANG,
+				A_WP_GRENADE,
+				A_SATCHEL_CHARGE,
+				A_CLAYMORE,
+				A_C4,
+				A_MPBOMB,
+				A_M203_HE,
+				A_M203_IL,
+				A_M203_SMOKE,
+				A_M203_GAS,
+				A_F18_MISSILE,
+				A_EXPLODING_BARREL,
+				A_HE_GRENADE,
+				A_12GAUGE,
+				A_M203_FRAG,
+				A_GL_FRAG,
+				A_GL_IL,
+				A_GL_SMOKE,
+				A_GL_GAS,
+				A_9X19S,
+				A_9X19SD,
+				A_556X45SD,
+				A_762X51SD,
+				A_762X39SD,
+				A_57X28,
+
+				AMMO_END = 254
+			};
+
+			enum EPROJECTILE_TYPE
+			{
+				PROJECTILE_TYPE_NORMAL,
+				PROJECTILE_TYPE_ONE_FRAME,
+				PROJECTILE_TYPE_ONE_FRAME_SHOTGUN
+			};
+
+			enum EPROJECTILE_STATE
+			{
+				PROJECTILE_STATE_EXPIRED,
+				PROJECTILE_STATE_FLYOUT,
+				PROJECTILE_STATE_AT_REST,
+				PROJECTILE_STATE_TO_BE_DETONATED,
+				PROJECTILE_STATE_DETONATION_TO_BE_HANDLED,
+				PROJECTILE_STATE_WAS_DETONATED,
+				PROJECTILE_STATE_TO_BE_REMOVED
+			};
+
+			enum EGRENADE_STATE
+			{
+				GRENADE_STATE_CREATE,
+				GRENADE_STATE_NEWPOS,
+				GRENADE_STATE_DETONATE,
+				GRENADE_STATE_REMOVE
+			};
+
+			enum ESEALBONES_INDEX
+			{
+				ESEALBONES_MIN = 0,
+				ESEALBONES_root = ESEALBONES_MIN,
+				ESEALBONES_aimnodes,
+				ESEALBONES_lfoot,			//	left heel
+				ESEALBONES_rfoot,			//	right heel
+				ESEALBONES_lhand,			//	left hand
+				ESEALBONES_spinelo,			//	lower spine
+				ESEALBONES_rhand,			//	right hand
+				ESEALBONES_hips,
+				ESEALBONES_head,			//	center head
+				ESEALBONES_neck,			//	neck
+				ESEALBONES_spinehi,			//	upper spine
+				ESEALBONES_lthigh,			//	left hip
+				ESEALBONES_rthigh,			//	right hip
+				ESEALBONES_rcalf,			//	right knee
+				ESEALBONES_rbicep,			//	right shoulder
+				ESEALBONES_rforearm,		//	right elbow
+				ESEALBONES_lbicep,			//	left shoulder
+				ESEALBONES_lforearm,		//	left elbow
+				ESEALBONES_lscap,
+				ESEALBONES_rscap,
+				ESEALBONES_lshoulder_wgt,	//	left shoulder
+				ESEALBONES_rshoulder_wgt,	//	right shoulder
+				ESEALBONES_lcalf,			//	knee
+				ESEALBONES_ltoe,			//	foot	
+				ESEALBONES_rtoe,			//	foot
+				ESEALBONES_weapon,
+				ESEALBONES_rifle,
+				ESEALBONES_pistol,
+				ESEALBONES_grenade,
+				ESEALBONES_reyeball,
+				ESEALBONES_leyeball,
+				ESEALBONES_reyelid,
+				ESEALBONES_leyelid,
+				ESEALBONES_MAX = ESEALBONES_leyelid
+			};
+
+			enum EZOOM_STATE : char
+			{
+				EZoomState_default = 0,
+				EZoomState_1stperson = 1,
+				EZoomState_unknown = 2,
+				EZoomState_binocs = 3,
+				EZoomState_weapondef_1 = 4
+			};
+
+			enum class ESEAL_TEAMS : i32_t
+			{
+				// MULTIPLAYER
+				ETeam_SEALS = 0x40000001,			//	Seal
+				ETeam_TERRORIST = 0x80000100,		//	Terrorist
+				ETeam_TURRET = 0x48000000,			//	Turret
+				ETeam_SPECTATOR = 0x00010000,		//	Spectator
+				ETeam_GHOST = 0x00020000,			//	test
+
+				// CAMPAIGN
+				ETeam_SP_ABLE = 0x84000006,			//	Alpha Team
+				ETeam_SP_BRAVO = 0x8400000A,		//	Bravo Team
+				ETeam_SP_ENEMY_A = 0x40000050,		//	Iron Brother / Iron Leader
+				ETeam_SP_ENEMY_B = 0x40000100,		//	
+				ETeam_SP_ENEMY_C = 0x40000210,		//	
+				ETeam_SP_ENEMY_D = 0x40000410,		//	
+				ETeam_SP_ENEMY_E = 0x40000810,		//	
+				ETeam_SP_ENEMY_F = 0x40001010,		//	
+				ETeam_SP_ENEMY_G = 0x40002010,		//	
+				ETeam_SP_ENEMY_H = 0x40004010,		//	
+				ETeam_SP_ENEMY_I = 0x40021010,		//	
+				ETeam_NONE = 0
+			};
+
+			enum ESEAL_STANCE : char
+			{
+				ESealStance_Stand = 0,
+				ESealStance_Crouch = 1,
+				ESealStance_Prone = 2
+			};
+
+			enum ESEAL_LEAN : char
+			{
+				ESealLean_LEFT,
+				ESealLean_UP,
+				ESealLean_RIGHT,
+				ESealLean_NONE
+			};
+
+			enum EWEAPONEQUIP_INDEX : __int32
+			{
+				EWeaponIndex_Primary = 0,
+				EWeaponIndex_Secondary = 1,
+				EWeaponIndex_EqSlot1 = 2,
+				EWeaponIndex_EqSlot2 = 3,
+				EWeaponIndex_EqSlot3 = 4
+			};
+
+			enum  EWEAPON_ENCUMBRANCE : char
+			{
+				LIGHTLY_ENCUMBERED,
+				MEDIUM_ENCUMBERED,
+				HEAVY_ENCUMBERED,
+				VERY_HEAVILY_ENCUMBERED,
+				NOT_ENCUMBERED,
+				NUM_ECUMBTYPES
+			};
+
+			enum EWEAPON_FIREMODE : __int32
+			{
+				EFireMode_Default = 0,
+				EFireMode_Single = 1,
+				EFireMode_Burst = 2,
+				EFireMode_Auto = 3,
+				EFireMode_Special,
+				NUM_FIREMODES
+			};
+
+			/*
+				Weapons
+
+				NOTE: points to static addresses in the game module defined in SOCOM1_package.h
+			*/
+			enum class EWEAPON : i32_t
+			{
+				EWeapon_EMPTY = 0,
+				EWeapon_M4A1 = WEAPON_M4A1,
+				EWeapon_M4A1_SD = WEAPON_M4A1_SD,
+				EWeapon_M4A1_M203 = WEAPON_M4A1_M203,
+				EWeapon_M16A2 = WEAPON_M16A2,
+				EWeapon_M16A2_M203 = WEAPON_M16A2_M203,
+				EWeapon_552 = WEAPON_552,
+				EWeapon_AK47 = WEAPON_AK47,
+				EWeapon_AKS74 = WEAPON_AKS74,
+				EWeapon_M14 = WEAPON_M14,
+				EWeapon_M63A = WEAPON_M63A,
+				EWeapon_M60E3 = WEAPON_M60E3,
+				EWeapon_STONER63 = WEAPON_STONER_63,	//	unknown, not used in SOCOM 1
+				EWeapon_Remington870 = WEAPON_REMINGTON_870,	//	unknown, not used in SOCOM 1
+				EWeapon_MK3_A2 = WEAPON_MK3_A2_SHOTGUN,	//	unknown, not used in SOCOM 1	
+				EWeapon_UZI = WEAPON_9M_SUB,
+				EWeapon_F90 = WEAPON_F90,
+				EWeapon_HK5 = WEAPON_HK5,
+				EWeapon_HK5_SD = WEAPON_HK5_SD,
+				EWeapon_SR25 = WEAPON_SR25,
+				EWeapon_SR25_SD = WEAPON_SR25_SD,
+				EWeapon_M40A1 = WEAPON_M40A1,
+				EWeapon_M87ELR = WEAPON_M87ELR,
+				EWeapon_M82A1A = WEAPON_M82A1A,
+				EWeapon_M79 = WEAPON_M79,
+				EWeapon_MGL = WEAPON_MGL,
+				EWeapon_M203 = WEAPON_M203,
+				EWeapon_M9 = WEAPON_M9,
+				EWeapon_9MM = WEAPON_9MM_Pistol,
+				EWeapon_P226 = WEAPON_P226,
+				EWeapon_F57 = WEAPON_F57,
+				EWeapon_MODEL18 = WEAPON_MODEL_18,
+				EWeapon_DE50 = WEAPON_DE50,
+				EWeapon_MARK23 = WEAPON_MARK_23,
+				EWeapon_MARK23_SD = WEAPON_MARK23_SD,
+				EWeapon_M67 = WEAPON_M67,
+				EWeapon_HE = WEAPON_HE_GRENADE,
+				EWeapon_SMOKE = WEAPON_SMOKE,
+				EWeapon_FLASHBANG = WEAPON_FLASHBANG,
+				EWeapon_2XAMMO = WEAPON_2X_AMMO,
+				EWeapon_M79_HE = WEAPON_M79_HE,
+				EWeapon_M79_FRAG = WEAPON_M79_FRAG,
+				EWeapon_M79_SMOKE = WEAPON_M79_SMOKE,
+				EWeapon_M203_HE = WEAPON_M203_HE,
+				EWeapon_M203_FRAG = WEAPON_M203_FRAG,
+				EWeapon_M203_SMOKE = WEAPON_M203_SMOKE,
+				EWeapon_C4 = WEAPON_C4,
+				EWeapon_CLAYMORE = WEAPON_CLAYMORE,
+				EWeapon_SATCHEL = WEAPON_SATCHEL,
+				EWeapon_MPBOMB = WEAPON_MPBOMB,	//	unknown, not used in SOCOM 1
+				EWeapon_KNIFE = WEAPON_KNIFE,		//	unknown, not used in SOCOM 1
+				EWeapon_FLASHLIGHT = WEAPON_FLASHLIGHT,	//	unknown, not used in SOCOM 1
+				EWeapon_DETONATOR = WEAPON_DETONATOR,	//	unknown, not used in SOCOM 1
+				EWeapon_BINOCULARS = WEAPON_BINOCULARS,	//	unknown, not used in SOCOM 1
+				EWeapon_RESTRAINTS = WEAPON_RESTRAINTS,	//	unknown, not used in SOCOM 1
+				EWeapon_KEVLAR_ARMOR = WEAPON_KEVLAR_ARMOR,	//	unknown, not used in SOCOM 1
+				EWeapon_KEVLAR_ARMOR_INSERT = WEAPON_KEVLAR_ARMOR_INSERT,	//	unknown, not used in SOCOM 1
+				EWeapon_ExplodingFuel = WEAPON_EXPLODING_FUEL,	//	unknown, not used in SOCOM 1
+				EWeapon_ATG_MISSILE = WEAPON_ATG_MISSILE,	//	unknown, not used in SOCOM 1
+				EWeapon_SATCHEL_EXPLOSION = WEAPON_SATCHEL_EXPLOSION,	//	unknown, not used in SOCOM 1
+				EWeapon_LASER_DESIGNATOR = WEAPON_LASER_DESIGNATOR,	//	unknown, not used in SOCOM 1
+			};
+
+			/*
+				Weapon Ammo Types
+
+				NOTE: points to static addresses in the game module defined in SOCOM1_package.h
+			*/
+			enum class EAMMO : i32_t
+			{
+				EWeaponAmmo_EMPTY = 0,
+
+				EWeaponAmmo_M4A1 = AMMO_556x45,
+				EWeaponAmmo_M4A1_M203 = AMMO_556x45,
+				EWeaponAmmo_M4A1_SD = AMMO_556x45_SD,
+				EWeaponAmmo_M16A2 = AMMO_556x45,
+				EWeaponAmmo_M16A2_M203 = AMMO_556x45,
+				EWeaponAmmo_552 = AMMO_556x45,
+				EWeaponAmmo_AK74 = AMMO_762x39,
+				EWeaponAmmo_AKS74 = AMMO_545x39,
+				EWeaponAmmo_M14 = AMMO_762x51,
+
+				EWeaponAmmo_UZI = AMMO_9x19P,
+				EWeaponAmmo_HK5 = AMMO_9x19P,
+				EWeaponAmmo_HK5_SD = AMMO_9x19P_SD,
+				EWeaponAmmo_F90 = AMMO_57x28,
+
+				EWeaponAmmo_M60E3 = AMMO_762x51,
+				EWeaponAmmo_M63A = AMMO_556x45,
+
+				EWeaponAmmo_SR25 = AMMO_762x51,
+				EWeaponAmmo_SR25_SD = AMMO_762x51,
+				EWeaponAmmo_M40A1 = AMMO_762x51,
+				EWeaponAmmo_M82A1A = AMMO_50BMG,
+				EWeaponAmmo_M87ELR = AMMO_50BMG,
+
+				//	EWeaponAmmo_M79 = AMMO_2xAmmo,
+				//	EWeaponAmmo_MGL = AMMO_2xAmmo,
+
+				EWeaponAmmo_9MM = AMMO_9x19P,
+				EWeaponAmmo_P226 = AMMO_9x19P,
+				EWeaponAmmo_M18 = AMMO_9x19P,
+				EWeaponAmmo_F57 = AMMO_57x28,
+				EWeaponAmmo_DE50 = AMMO_50AE,
+				EWeaponAmmo_MK23 = AMMO_45ACP,
+				EWeaponAmmo_MK23_SD = AMMO_45ACP,
+
+				EWeaponAmmo_M67 = AMMO_M67,
+				EWeaponAmmo_HE = AMMO_HE,
+				EWeaponAmmo_M141 = AMMO_M141,
+				EWeaponAmmo_Smoke = AMMO_SMOKE,
+				EWeaponAmmo_Claymore = AMMO_CLAYMORE,
+				EWeaponAmmo_C4 = AMMO_C4,
+
+				EWeaponAmmo_M79_HE = AMMO_M79_HE,
+				EWeaponAmmo_M79_FRAG = AMMO_M79_FRAG,
+				EWeaponAmmo_M79_SMOKE = AMMO_M79_SMOKE,
+				EWeaponAmmo_M203_HE = AMMO_M203_HE,
+				EWeaponAmmo_M203_FRAG = AMMO_M203_FRAG,
+				EWeaponAmmo_M203_SMOKE = AMMO_M203_SMOKE,
+
+				EWeaponAmmo_Satchel = AMMO_SATCHEL,
+				EWeaponAmmo_LONGRIFLE = AMMO_LONGRIFLE,	//	unknown, not used in SOCOM 1
+				EWeaponAmmo_SHOTGUN = AMMO_12GUAGE,	//	unknown, not used in SOCOM 1
+				EWeaponAmmo_MP_BOMB = AMMO_MPBOMB,	//	unknown, not used in SOCOM 1
+				EWeaponAmmo_ATG_Missile = AMMO_MISSILE,	//	unknown, not used in SOCOM 1
+				EWeaponAmmo_ExplosiveStuff = AMMO_EXPLOSIVE_STUFF,	//	unknown, not used in SOCOM 1
+
+				//	EWeaponAmmo_2xAmmo = AMMO_2xAmmo,
+			};
+		}
+
+		namespace Structs
+		{
+
+			struct RFloat
+			{
+				float min;
+				float range;
+			};
+
+			struct SSealStats
+			{
+				int mHeadshots; //0x0000
+				int mHeadHits; //0x0004
+				int mHits; //0x0008
+				int mShotsFired; //0x000C
+				int mKills; //0x0010
+				int mWasHit; //0x0014
+				int mDeaths; //0x0018
+				int mHostages; //0x001C
+				int mBasesBlown; //0x0020
+				int mHostagesRescued; //0x0024
+				float mAccuracy; //0x0028
+				int mTimesSeen; //0x002C
+				int mStealthKills; //0x0030
+				int mRestrains; //0x0034
+				int mGrenadesThrown; //0x0038
+				int mCqcTakedowns; //0x003C
+				int mPrimaryRoundsFired; //0x0040
+				int mSecondaryRoundsFired; //0x0044
+				__int16 mMVPScore; //0x0048
+				int mRoundsWon; //0x004A
+				int mRoundsLost; //0x004E
+			}; //Size: 0x0052
+
+			struct CZKit
+			{
+				// CZSeal
+				//	__int32							mTotalShotsFired;			//0x04DC
+				//	char							pad_04E0[48];				//0x04E0
+				//	__int32							mPrimaryShotsFired;			//0x0510
+				//	__int32							mSecondaryShotsFired;		//0x0514
+				//	char							pad_0518[52];				//0x0518
+				//	float							mRecoilPunch;				//0x054C
+				//	char							pad_0550[188];				//0x0550
+				//	i32_t							mPrimaryWeapon;				//0x060C	* CZWeapon
+				//	i32_t							mSecondaryWeapon;			//0x0610	* CZWeapon
+				//	i32_t							mEqSlot1;					//0x0614	* CZWeapon
+				//	i32_t							mEqSlot2;					//0x0618	* CZWeapon
+				//	i32_t							mEqSlot3;					//0x061C	* CZWeapon
+				//	char							pad_0620[100];				//0x0620
+				//	__int32							mPrimaryAmmoType;			//0x0684	* CZAmmo
+				//	__int32							mSecondaryAmmoType;			//0x0688	* CZAmmo
+				//	__int32							mEqSlot1AmmoType;			//0x068C	* CZAmmo
+				//	__int32							mEqSlot2AmmoType;			//0x0690	* CZAmmo
+				//	__int32							mEqSlot3AmmoType;			//0x0694	* CZAmmo
+				//	char							pad_0698[100];				//0x0698
+				//	__int32							mPrimaryMags[10];			//0x06FC
+				//	__int32							mSecondaryMags[10];			//0x0724
+				//	__int32							mEqSlot1Ammo;				//0x074C
+				//	char							pad_0750[36];				//0x0750
+				//	__int32							mEqSlot2Ammo;				//0x0774
+				//	char							pad_0778[36];				//0x0778
+				//	__int32							mEqSlot3Ammo;				//0x079C
+				//	char							pad_07A0[1156];				//0x07A0
+				//	Enums::EWEAPON_FIREMODE			mPrimaryFireType;			//0x0C24
+				//	Enums::EWEAPON_FIREMODE			mSecondaryFireType;			//0x0C28
+				//	char							pad_0C2C[272];				//0x0C2C
+				//	__int32							mCurrentShotsFired;			//0x0D3C
+				//	float							mFireCooldown;				//0x0D40
+				//	Enums::EWEAPONEQUIP_INDEX				mCurrentWeaponIndex;		//0x0D44
+				//	char							pad_0D48[4];				//0x0D48
+				//	__int32							mMaxWeaponIndex;			//0x0D4C
+				//	char							pad_0D50[308];				//0x0D50
+				//	__int32							mWeaponReadyState;			//0x0E84
+
+				bool m_first : 1;						
+				bool m_reticuletypeChanged : 1;
+				bool m_weaponinfoChanged : 1;
+				bool m_retblocked : 1;
+				bool m_nvg_enabled : 1;
+				bool m_binocs_enabled : 1;
+				bool m_lase_echo : 1;
+				bool m_lase_deploy_echo : 1;
+				bool m_lensfx_enable : 1;
+				bool m_waiting_to_fire : 1;
+				bool m_waiting_to_raise : 1;
+				bool m_changeToRifle : 1;
+				bool m_requested_item : 1;
+				bool m_current_requested_ammo : 1;
+				bool m_pad_bitfield : 1;
+				bool m_heartbeat_enabled : 1;
+				//	bool m_unused : 18;
+
+				char pad_0002[22]; //0x0002
+				Vec2 mRecoilPunch; //0x0018
+				Vec2 mPrevRecoilPunch; //0x0020
+				char pad_0028[8]; //0x0028
+				Vec3 mRifleKick; //0x0030
+				__int32 mFireRifleKickState; //0x003C
+				__int32 mHeartbeatState; //0x0040
+				Vec2 mHeartbeat; //0x0044
+				__int32 mCurItemReticule; //0x004C
+				Vec2 mScreenOffset; //0x0050
+				char pad_0058[132]; //0x0058
+				i32_t pWeapons[10]; //0x00DC	CZWeapon*
+				char pad_0104[80]; //0x0104
+				i32_t pAmmoTypes[10]; //0x0154	CZAmmo*
+				char pad_017C[80]; //0x017C
+				__int32 mPrimaryMags[10]; //0x01CC
+				__int32 mSecondaryMags[10]; //0x01F4
+				__int32 mEqSlot1Ammo; //0x021C
+				char pad_0220[36]; //0x0220
+				__int32 mEqSlot2Ammo; //0x0244
+				char pad_0248[36]; //0x0248
+				__int32 mEqSlot3Ammo; //0x026C
+				char pad_0270[1036]; //0x0270
+				__int32 PrimaryMagIndex; //0x067C
+				__int32 SecondaryMagIndex; //0x0680
+				char pad_0684[112]; //0x0684
+				Enums::EWEAPON_FIREMODE mWeaponFireTypes[2]; //0x06F4
+				char pad_06FC[272]; //0x06FC
+				__int32 mWeaponFireCount; //0x080C
+				float mWeaponFireDelta; //0x0810
+				Enums::EWEAPONEQUIP_INDEX mCurrentWeaponIndex; //0x0814
+				char pad_0818[4]; //0x0818
+				__int32 mMaxWeaponIndex; //0x081C
+				i32_t pSealBody; //0x0820	CZSealBody*
+				char pad_0824[108]; //0x0824
+
+				bool GetEquippedWeapon(i32_t& outWeapon);									//	attempts to retrieve equipped weapon, returns true if outWeapon != 0
+				bool GetEquippedAmmo(i32_t& outAmmo);										//	attempts to retrieve equipped ammo type, returns true if outAmmo != 0
+				bool GetWeaponAtIndex(const Enums::EWEAPONEQUIP_INDEX& index, i32_t& outWeapon);	//	attempts to retrieve weapon, returns true if outWeapon != 0
+				bool GetAmmoAtIndex(const Enums::EWEAPONEQUIP_INDEX& index, i32_t& outAmmo);		//	attempts to retrieve ammo type, returns true if outAmmo != 0
+				bool GetWeaponName(const Enums::EWEAPONEQUIP_INDEX& index, std::string& outName);	//	attempts to retrieve weapon name , returns true if size of string > 0
+				bool GetAmmoName(const Enums::EWEAPONEQUIP_INDEX& index, std::string& outName);	//	attempts to retrieve ammo name , returns true if size of string > 0
+				void SetHeartbeatEnabled(bool enabled);										//	sets heartbeat enabled state
+				bool GetHeartbeatEnabled() const;											//	returns heartbeat enabled state
+				std::string GetWeaponName(const Enums::EWEAPONEQUIP_INDEX& index);
+				std::string GetAmmoName(const Enums::EWEAPONEQUIP_INDEX& index);
+			};
+		}
+		
 		enum EWeaponSlot : uint32_t
 		{
 			Primary,		// = 0x60C,
@@ -37,69 +670,48 @@ namespace PlayStation2
 			- S = Secondary
 			- EQ = Equipment
 		*/
-		enum class EWeapon : __int32
+		enum class EWEAPON : __int32
 		{
 			// Assault Rifles
-			EWeapon_P_AR_M4A1_M203			= 0xCC4270,
-			EWeapon_P_AR_M4A1_SD			= 0xCC3F80,
-			EWeapon_P_AR_M16A2				= 0xCC36E0,
+			EWeapon_M4A1_M203			= 0xCC4270,
+			EWeapon_M4A1_SD			= 0xCC3F80,
+			EWeapon_M16A2				= 0xCC36E0,
 			EWeapon_P_AR_M16_M203			= 0xCC39C0,
-			EWeapon_P_AR_552				= 0xCC4550,
+			EWeapon_552				= 0xCC4550,
 			EWeapon_P_AR_AK74				= 0xCC4850,
-			EWeapon_P_AR_AKS74				= 0xCC4B20,
+			EWeapon_AKS74				= 0xCC4B20,
 			
 			//	
 			EWeapon_P_SMG_9MM				= 0xCC61F0,
-			EWeapon_P_SMG_HK5				= 0xCC5970,
-			EWeapon_P_SMG_HK5_SD			= 0xCC5C40, 
+			EWeapon_HK5				= 0xCC5970,
+			EWeapon_HK5_SD			= 0xCC5C40, 
 			
 			//	
-			EWeapon_P_SNIPER_M40A1			= 0xCC67A0,
+			EWeapon_M40A1			= 0xCC67A0,
 
 			//	
-			EWeapon_S_PISTOL_9MM			= 0xCC22D0,
+			EWeapon_9MM			= 0xCC22D0,
 			EWeapon_S_PISTOL_9MM_SD			= 0xCC2B60,
-			EWeapon_S_PISTOL_MK23			= 0xCC1A10,
-			EWeapon_S_PISTOL_MK23_SD		= 0xCC2880,
+			EWeapon_MARK23			= 0xCC1A10,
+			EWeapon_MARK23_SD		= 0xCC2880,
 			EWeapon_S_PISTOL_226			= 0xCC25B0,
-			EWeapon_S_PISTOL_F57			= 0xCC1CF0,
-			EWeapon_S_PISTOL_DE50			= 0xCC1FD0,
+			EWeapon_F57			= 0xCC1CF0,
+			EWeapon_DE50			= 0xCC1FD0,
 
 			//	
 			EWeapon_EQ_Flashbang			= 0xCC8A60,
-			EWeapon_EQ_C4					= 0xCC9300,
+			EWeapon_C4					= 0xCC9300,
 			EWeapon_EQ_Claymore				= 0xCC9030,
 			EWeapon_EQ_Satchel				= 0xCC8D50,
-			EWeapon_EQ_M67					= 0xCC81A0,
-			EWeapon_EQ_HE					= 0xCC8490,
+			EWeapon_M67					= 0xCC81A0,
+			EWeapon_HE					= 0xCC8490,
 			EWeapon_EQ_Smoke				= 0xCC8760,
-			EWeapon_EQ_AMMOx2				= 0xCCB800,
+			EWeapon_2XAMMO				= 0xCCB800,
 			EWeapon_EQ_M203_HE				= 0xCC9B50,
 			EWeapon_EQ_M203_FRAG			= 0xCC9E30,
 			EWeapon_EQ_M203_SMOKE			= 0xCCA120,
 		};
-		const char* GetWeaponName(EWeapon weapon);
-		/*
-			static const char* PrimaryWeapons[4] =
-			{
-				"M4A1 SD",						//	0
-				"552", 							//	1
-				"9mm Sub",						//	2
-				"abs" 							//	3
-			};
-			static const char* SecondaryWeapons[5] =
-			{
-				"9MM Pistol",					//	0
-				"abs", 							//	1
-				"abs2", 						//	2
-				"abs3", 						//	3
-				"abs4" 							//	4
-			};
-			static const char* EquipmentWeapons[1] =
-			{
-				"Flashbang"						//	0
-			};
-		*/
+		const char* GetWeaponName(EWEAPON weapon);
 
 		enum class EAmmoType : unsigned __int32
 		{
@@ -206,7 +818,7 @@ namespace PlayStation2
 				"BRAVO",			//	4
 			};
 		*/
-		
+
 		enum class EMap : unsigned __int32
 		{
 
@@ -229,15 +841,34 @@ namespace PlayStation2
 
 		};
 
+		//	
+		struct FViewModel
+		{
+			Vec4 right;		//	Vector3 : right vector
+			Vec4 up;		//	Vector3 : up vector
+			Vec4 fwd;		//	Vector3 : look vector ( - is forward )
+			Vec4 pos;		//	Vector3 : position
+		};
+
+		//	
+		struct FViewCache
+		{
+			Vec3 m1;	//0x0000	//	
+			Vec3 m2;	//0x000C	//	
+			Vec3 m3;	//0x0018	//	
+			Vec3 m4;	//0x0024	//	tilt 
+			Vec3 m5;	//0x0030	//	z = camera distance from player
+			Vec3 m6;	//0x003C
+		};	//Size: 0x0048
 
 		//	
 		template<typename Z>
 		struct ZArrayIterator
 		{
 		private:
-			__int32 _next;		//	might be start	??
-			__int32 _prev;		//	first object in the array will point to the start.
-			__int32 _data;		//	Z
+			__int32 _next;		//	next item in the array, points to the next ZArrayIterator<Z>
+			__int32 _prev;		//	previous item in the array, points to the previous ZArrayIterator<Z>
+			__int32 _data;		//  pointer to data type
 		
 		public:
 			
@@ -255,18 +886,18 @@ namespace PlayStation2
 				_data = data;
 			}
 
-			Z Data() const { return reinterpret_cast<Z>(PS2Memory::GetModuleBase() + _data); }
-			ZArrayIterator<Z> Next() const { return PS2Memory::ReadShort<ZArrayIterator<Z>>(_next); }
-			ZArrayIterator<Z> Prev() const { return PS2Memory::ReadShort<ZArrayIterator<Z>>(_prev); }
+			Z Data() const { return reinterpret_cast<Z>(PS2Memory::GetEEBase() + _data); }
+			ZArrayIterator<Z> Next() const { return PS2Memory::ReadEE<ZArrayIterator<Z>>(_next); }
+			ZArrayIterator<Z> Prev() const { return PS2Memory::ReadEE<ZArrayIterator<Z>>(_prev); }
 		};
 
 		template<typename Z>
 		struct ZArray
 		{
 		private:
-			__int32 _count;
-			__int32 _begin;
-			__int32 _end;
+			__int32 _count;		//	number of elements in the array
+			__int32 _begin;		//	first item in the array, points to the first ZArrayIterator<Z>
+			__int32 _end;		//	last item in the array, points to the last ZArrayIterator<Z>
 		
 		public:
 			ZArray()
@@ -285,30 +916,29 @@ namespace PlayStation2
 
 			int Count() const { return _count; }
 			bool IsValid() const { return false; }	//	check if count > 0 && if _begin & _end are <= 0
-			ZArrayIterator<Z> GetIterator() const
-			{
-				return PS2Memory::ReadShort<ZArrayIterator<Z>>(_begin);
-			}
+			ZArrayIterator<Z> GetIterator() const { return PS2Memory::ReadEE<ZArrayIterator<Z>>(_begin); }
 
 			std::vector<Z> Data() const
 			{
-				std::vector<Z> result;
+				std::vector<Z> result;	/* result container */
 
 				if (_count > 0)
 				{
-					ZArrayIterator<Z> it = GetIterator();
-					ZArrayIterator<Z> end = it.Prev();
+					ZArrayIterator<Z> it = GetIterator();	/* get first item */
+					ZArrayIterator<Z> end = it.Prev();		/* get last item */
 					
 					do
 					{
+						/* get the data */
 						Z data = it.Data();
 
-						if (data > 0)
-							result.push_back(data);
+						/* populate result with data */
+						result.push_back(data);
 
+						/* move on to the next item */
 						it = it.Next();
 
-					} while (it.Data() != end.Data());
+					} while (it.Data() != end.Data());	/* loop until the end */ 
 				}
 
 				return result;


### PR DESCRIPTION
This pull request introduces a set of foundational changes to the `SOCOM1_package.h` header for the SOCOM U.S. Navy Seals module. The main focus is on adding weapon and ammo type definitions, utility functions for querying game data, and organizing code to support future development and debugging. These changes will make it easier to reference weapons and ammo by name and index, and provide tools for extracting game data during development.

### Weapon and Ammo Definitions

* Added `#define` constants for all weapon and ammo types used in SOCOM 1, enabling easy reference to their IDs throughout the codebase.

### Utility Functions

* Introduced global functions: `GetWeaponByIndex`, `GetAmmoTypeByIndex`, `GetTeamIDByIndex`, and `GetBoneNameByIndex` for retrieving game data by index.

### Debugging and Data Extraction Tools

* Added the `Dumper` namespace with functions to dump mission info, weapon stats, ammo stats, and bone names, facilitating debugging and reverse engineering.

### Code Organization

* Included additional headers (`PCSX2/CDK.h`, `data/names.h`) and forward typedef for `i32_t` to support new functionality and maintain type consistency. [[1]](diffhunk://#diff-578e632b8172bee2b250d01aaa66886bcca757b8cdd2d59d475dd81a0fb2e45eR2) [[2]](diffhunk://#diff-578e632b8172bee2b250d01aaa66886bcca757b8cdd2d59d475dd81a0fb2e45eR18-R136)